### PR TITLE
Respond to early 'set port' with error instead of silent failure

### DIFF
--- a/scantool/scantool_set.c
+++ b/scantool/scantool_set.c
@@ -168,7 +168,13 @@ static int cmd_set_custom(int argc, char **argv) {
 	bool show_current=0;
 	int newval;
 
-	if (!global_dl0d) return CMD_FAILED;
+	if (!global_dl0d) {
+		// no L0 selected yet
+		if (strcmp(argv[0], "?") == 0)
+			return CMD_OK;
+		printf("No such item !\n");
+		return CMD_FAILED;
+	}
 
 	if (strcmp(argv[0], "?") == 0) {
 		//list available custom commands for the current L0.

--- a/scantool/scantool_set.c
+++ b/scantool/scantool_set.c
@@ -172,7 +172,7 @@ static int cmd_set_custom(int argc, char **argv) {
 		// no L0 selected yet
 		if (strcmp(argv[0], "?") == 0)
 			return CMD_OK;
-		printf("No such item !\n");
+		printf("No such item !\nAdditional items may be available after setting the interface type.\nUse \"set interface NAME\" to set the interface type.\n");
 		return CMD_FAILED;
 	}
 


### PR DESCRIPTION
If user tries to set a non-existent parameter before selecting an L0
(for example, 'set port ...' before 'set interface ...'), print an
error message instead of silently not setting anything.
