### PR TITLE
elm/kwp6227 wakeup message changes

### DIFF
--- a/scantool/diag.h
+++ b/scantool/diag.h
@@ -138,7 +138,7 @@ typedef uint16_t flag_type;	//this is used for L2 type flags (see diag_l2.h)
  * Only applicable if DIAG_L1_DOESKEEPALIVE is set
  *
  * data = (struct diag_msg *).
- * The (struct diag_msg)->data member must be a raw message (including headers, checksums etc)
+ * The (struct diag_msg)->data member must be a raw message (including headers)
  *
  * data can be freed by caller after the ioctl (L0 will make a copy of the message data as required)
  */

--- a/scantool/diag_l0_elm.c
+++ b/scantool/diag_l0_elm.c
@@ -1121,7 +1121,7 @@ static int elm_setwm(struct diag_l0_device *dl0d, struct diag_msg *pmsg) {
 
 	if (dev->elmflags & ELM_323_BASIC) {
 		fprintf(stderr, FLFMT "elm_setwm: ELM323 doesn't support setting wakeup message\n", FL);
-		return diag_iseterr(DIAG_ERR_GENERAL);
+		return diag_iseterr(DIAG_ERR_IOCTL_NOTSUPP);
 	}
 
 	if (pmsg->len != 4) {

--- a/scantool/diag_l0_elm.c
+++ b/scantool/diag_l0_elm.c
@@ -683,6 +683,22 @@ elm_bogusinit(struct diag_l0_device *dl0d, unsigned int timeout)
 
 }
 
+// set wakeup message
+static int
+elm_updatewm(struct diag_l0_device *dl0d)
+{
+	struct elm_device *dev;
+	uint8_t wm[18];
+
+	dev = (struct elm_device *)dl0d->l0_int;
+	sprintf((char *) wm, "ATWM %02X %02X %02X %02X\x0D", dev->wm->data[0], dev->wm->data[1], dev->wm->data[2], dev->wm->data[3]);
+	if (elm_sendcmd(dl0d, wm, 17, 500, NULL) < 0) {
+		fprintf(stderr, FLFMT "elm_updatewm: ATWM failed\n", FL);
+		return diag_iseterr(DIAG_ERR_GENERAL);
+	}
+	return 0;
+}
+
 /*
  * Do manual wakeup on the bus, if supported
  * ret 0 if ok
@@ -730,13 +746,9 @@ elm_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in)
 
 			// set wakeup message if applicable
 			if (dev->wm != NULL) {
-				uint8_t wm[18];
-				sprintf((char *) wm, "ATWM %02X %02X %02X %02X\x0D", dev->wm->data[0], dev->wm->data[1], dev->wm->data[2], dev->wm->data[3]);
-				rv=elm_sendcmd(dl0d, wm, 17, 500, NULL);
-				if (rv < 0) {
-					fprintf(stderr, FLFMT "elm_initbus: ATWM failed\n", FL);
-					return diag_iseterr(DIAG_ERR_GENERAL);
-				}
+				rv=elm_updatewm(dl0d);
+				if (rv < 0)
+					return rv;
 			}
 
 			sprintf((char *) sethdr, "ATSH %02X %02X %02X\x0D", fmt, tgt, src);
@@ -768,13 +780,9 @@ elm_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in)
 
 			// set wakeup message if applicable
 			if (dev->wm != NULL) {
-				uint8_t wm[18];
-				sprintf((char *) wm, "ATWM %02X %02X %02X %02X\x0D", dev->wm->data[0], dev->wm->data[1], dev->wm->data[2], dev->wm->data[3]);
-				rv=elm_sendcmd(dl0d, wm, 17, 500, NULL);
-				if (rv < 0) {
-					fprintf(stderr, FLFMT "elm_initbus: ATWM failed\n", FL);
-					return diag_iseterr(DIAG_ERR_GENERAL);
-				}
+				rv=elm_updatewm(dl0d);
+				if (rv < 0)
+					return rv;
 			}
 
 			//set init address

--- a/scantool/diag_l2_kwp6227.c
+++ b/scantool/diag_l2_kwp6227.c
@@ -165,6 +165,8 @@ dl2p_6227_startcomms(struct diag_l2_conn *d_l2_conn, flag_type flags,
 	struct diag_serial_settings set;
 	struct diag_l2_kwp6227 *dp;
 	int rv;
+	struct diag_msg wm={0};
+	uint8_t wm_data[]={0x82, 0, 0, 0xa1};
 	struct diag_l1_initbus_args in;
 
 	if (!(d_l2_conn->diag_link->l1flags & DIAG_L1_DOESFULLINIT) || !(d_l2_conn->diag_link->l1flags & DIAG_L1_DOESL2CKSUM)) {
@@ -200,6 +202,14 @@ dl2p_6227_startcomms(struct diag_l2_conn *d_l2_conn, flag_type flags,
 
 	(void)diag_l2_ioctl(d_l2_conn, DIAG_IOCTL_IFLUSH, NULL);
 	diag_os_millisleep(300);
+
+	wm_data[1] = dp->dstaddr;
+	wm_data[2] = dp->srcaddr;
+	wm.data = wm_data;
+	wm.len = sizeof(wm_data);
+	rv = diag_l2_ioctl(d_l2_conn, DIAG_IOCTL_SETWM, &wm);
+	if (rv < 0)
+		goto err;
 
 	in.type = DIAG_L1_INITBUS_5BAUD;
 	in.addr = with_parity(target, diag_par_o);


### PR DESCRIPTION
Implement SETWM ioctl for elm and use the ioctl for kwp6227 rather than having elm look at the key bytes to determine the wakeup message.