### PR TITLE
A few Volvo additions

### DIFF
--- a/scantool/diag_l7_d2.h
+++ b/scantool/diag_l7_d2.h
@@ -40,6 +40,7 @@ int diag_l7_d2_ping(struct diag_l2_conn *d_l2_conn);
 int diag_l7_d2_read(struct diag_l2_conn *d_l2_conn, enum namespace ns, uint16_t addr, int buflen, uint8_t *out);
 int diag_l7_d2_dtclist(struct diag_l2_conn *d_l2_conn, int buflen, uint8_t *out);
 int diag_l7_d2_cleardtc(struct diag_l2_conn *d_l2_conn);
+int diag_l7_d2_io_control(struct diag_l2_conn *d_l2_conn, uint8_t id, uint8_t reps);
 
 #if defined(__cplusplus)
 }

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -116,6 +116,7 @@ static int cmd_850_dtc(int argc, UNUSED(char **argv));
 static int cmd_850_cleardtc(int argc, UNUSED(char **argv));
 static int cmd_850_freeze(int argc, char **argv);
 static int cmd_850_scan_all(int argc, UNUSED(char **argv));
+static int cmd_850_test(int argc, char **argv);
 
 const struct cmd_tbl_entry v850_cmd_table[] =
 {
@@ -152,6 +153,8 @@ const struct cmd_tbl_entry v850_cmd_table[] =
 		cmd_850_cleardtc, 0, NULL},
 	{ "freeze", "freeze dtc1|all [dtc2 ...]", "Display freeze frame(s)",
 		cmd_850_freeze, 0, NULL},
+	{ "test", "test <testname>", "Test vehicle components",
+		cmd_850_test, 0, NULL},
 
 	{ "up", "up", "Return to previous menu level",
 		cmd_up, 0, NULL},
@@ -1477,5 +1480,35 @@ cmd_850_scan_all(int argc, UNUSED(char **argv))
 
 	printf("Scan-all done.\n");
 
+	return CMD_OK;
+}
+
+/*
+ * Test the specified vehicle component.
+ */
+static int
+cmd_850_test(int argc, char **argv) {
+	if (argc==2 && strcasecmp(argv[1], "fan1")==0 && global_l2_conn->diag_l2_destaddr==0x7a) {
+		if (diag_l7_d2_io_control(global_l2_conn, 0x0e, 3) == 0) {
+			printf("Activating engine cooling fan.\n");
+		} else {
+			printf("Unable to activate fan.\n");
+		}
+	} else if (argc==2 && strcasecmp(argv[1], "fan2")==0 && global_l2_conn->diag_l2_destaddr==0x7a) {
+		if (diag_l7_d2_io_control(global_l2_conn, 0x1f, 3) == 0) {
+			printf("Activating engine cooling fan.\n");
+		} else {
+			printf("Unable to activate fan.\n");
+		}
+	} else {
+		printf("Usage: test <testname>\n");
+		if (global_l2_conn->diag_l2_destaddr == 0x7a) {
+			printf("Available tests:\n");
+			printf("fan1 - Activate engine cooling fan, half speed (please keep fingers clear)\n");
+			printf("fan2 - Activate engine cooling fan, full speed (please keep fingers clear)\n");
+		} else {
+			printf("No available tests for this ECU.\n");
+		}
+	}
 	return CMD_OK;
 }

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -1488,6 +1488,9 @@ cmd_850_scan_all(int argc, UNUSED(char **argv))
  */
 static int
 cmd_850_test(int argc, char **argv) {
+	if(!valid_connection_status(CONNECTED_D2))
+		return CMD_OK;
+
 	if (argc==2 && strcasecmp(argv[1], "fan1")==0 && global_l2_conn->diag_l2_destaddr==0x7a) {
 		if (diag_l7_d2_io_control(global_l2_conn, 0x0e, 3) == 0) {
 			printf("Activating engine cooling fan.\n");

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -696,7 +696,9 @@ cmd_850_ping(int argc, UNUSED(char **argv))
 static void
 interpret_value(enum namespace ns, uint16_t addr, UNUSED(int len), uint8_t *buf)
 {
-	if (ns==NS_LIVEDATA && addr==0x0300) {
+	if (ns==NS_LIVEDATA && addr==0x0200) {
+		printf("Engine Coolant Temperature: %dC (%dF)\n", buf[1]-80, (buf[1]-80)*9/5+32);
+	} else if (ns==NS_LIVEDATA && addr==0x0300) {
 		/*ECU pin A27, MCU P7.1 input, divider ratio 8250/29750, 5Vref*/
 		printf("Battery voltage: %.1f V\n", (float)buf[0]*29750/8250*5/256);
 	} else if(ns==NS_MEMORY && addr==0x36 && global_l2_conn->diag_l2_destaddr==0x10) {

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -1134,6 +1134,7 @@ cmd_850_id_d2(void)
 {
 	uint8_t buf[15];
 	int rv;
+	int i;
 
 	rv = diag_l7_d2_read(global_l2_conn, NS_NV, 0xf0, sizeof(buf), buf);
 	if (rv < 0) {
@@ -1156,6 +1157,23 @@ cmd_850_id_d2(void)
 
 	printf("Hardware ID: P%02X%02X%02X%02X revision %.3s\n", buf[1], buf[2], buf[3], buf[4], buf+5);
 	printf("Software ID:  %02X%02X%02X%02X revision %.3s\n", buf[8], buf[9], buf[10], buf[11], buf+12);
+
+	if (global_l2_conn->diag_l2_destaddr == 0x7a) {
+		rv = diag_l7_d2_read(global_l2_conn, NS_NV, 1, sizeof(buf), buf);
+		if (rv < 0)
+			return CMD_OK;
+		if (rv != 10) {
+			printf("Identification response was %d bytes, expected %d\n", rv, 10);
+			return CMD_OK;
+		}
+		for (i=0; i<10; i++) {
+			if (!isdigit(buf[i])) {
+				printf("Unexpected characters in identification block\n");
+				return CMD_OK;
+			}
+		}
+		printf("Order number: %c %.3s %.3s %.3s\n",buf[0], buf+1, buf+4, buf+7);
+	}
 
 	return CMD_OK;
 }


### PR DESCRIPTION
These changes are relevant to Volvo 850/V70/C70/S70 with Motronic M4.4 using D2 protocol.

- Add order number to output of '850 id' (previously only retrieved/shown with KWP71)
- Add command to test engine cooling fan
- Live data scaling for Engine Coolant Temperature