### PR TITLE
Prettify code

### DIFF
--- a/scantool/diag.h
+++ b/scantool/diag.h
@@ -186,8 +186,7 @@ struct debugflags_descr {
  * There's probably no application for 0-length messages, but currently the various functions
  * don't complain when allocating/duplicating empty data.
  */
-struct diag_msg
-{
+struct diag_msg {
 	uint8_t	fmt;			/* Message format (doesn't absolutely need to be uint8_t) : */
 	#define DIAG_FMT_ISO_FUNCADDR	0x01	/* ISO Functional addressing (default : phys) */
 	#define DIAG_FMT_FRAMED		0x02	/* Rcvd data is framed, ie not raw. XXX DEPRECATED ! L0..L2 all do this.*/

--- a/scantool/diag.h
+++ b/scantool/diag.h
@@ -171,8 +171,8 @@ enum debugflag_enum {OPEN=DIAG_DEBUG_OPEN,
 // struct debugflags_descr : filled + used in scantool_debug.c
 struct debugflags_descr {
 	enum debugflag_enum mask;
-	const char * descr;		//associate short description for each flag.
-	const char * shortdescr;
+	const char *descr;		//associate short description for each flag.
+	const char *shortdescr;
 };
 
 /*
@@ -321,12 +321,12 @@ int diag_flmalloc(const char *name, const int line, void **p, size_t s);
 * @param elems: number of elements already in table
 * @return new table ptr, NULL if failed
 */
-char ** strlist_add(char ** list, const char * news, int elems);
+char **strlist_add(char **list, const char *news, int elems);
 
 /** Free argv-style string list
 * @param elems: number of strings in list
 */
-void strlist_free(char ** slist, int elems);
+void strlist_free(char **slist, int elems);
 
 #if defined(__cplusplus)
 }

--- a/scantool/diag_cfg.c
+++ b/scantool/diag_cfg.c
@@ -116,7 +116,7 @@ int diag_cfg_setopt(struct cfgi *cfgp, int optid) {
 
 //get param value, as new string to be free'd by caller.
 //for u8 / int types, sprintf with %X and %d formatters respectively
-char * diag_cfg_getstr(struct cfgi *cfgp) {
+char *diag_cfg_getstr(struct cfgi *cfgp) {
 	char *str;
 	const char *fmt;
 	size_t len;

--- a/scantool/diag_cfg.h
+++ b/scantool/diag_cfg.h
@@ -105,7 +105,7 @@ int diag_cfg_setopt(struct cfgi *cfgp, int optid);
 
 /** get param value: generates new string to be free'd by caller
 */
-char * diag_cfg_getstr(struct cfgi *cfgp);
+char *diag_cfg_getstr(struct cfgi *cfgp);
 
 /** free contents of *cfgp but not the struct itself
  */

--- a/scantool/diag_dtc.c
+++ b/scantool/diag_dtc.c
@@ -48,7 +48,7 @@ void diag_dtc_init(void) {
  * @return pointer to *buf, which may be useful to printf or fprintf...
  */
 
-char * diag_dtc_decode(uint8_t *data, int len,
+char *diag_dtc_decode(uint8_t *data, int len,
 	UNUSED(const char *vehicle), UNUSED(const char *ecu),
 	enum diag_dtc_protocol protocol,
 	char *buf, const size_t bufsize) {

--- a/scantool/diag_dtc.c
+++ b/scantool/diag_dtc.c
@@ -32,8 +32,7 @@
 
 
 //do not use *allocs or open handles in diag_dtc_init !
-void diag_dtc_init(void)
-{
+void diag_dtc_init(void) {
 }
 
 /** DTC decoding routine.
@@ -52,20 +51,17 @@ void diag_dtc_init(void)
 char * diag_dtc_decode(uint8_t *data, int len,
 	UNUSED(const char *vehicle), UNUSED(const char *ecu),
 	enum diag_dtc_protocol protocol,
-	char *buf, const size_t bufsize)
-{
+	char *buf, const size_t bufsize) {
 	char area;
 
-	switch (protocol)
-	{
+	switch (protocol) {
 	case dtc_proto_j2012:
 		if (len != 2) {
 			strncpy(buf, "DTC too short for J1850 decode\n", bufsize);
 			return buf;
 		}
 
-		switch ((data[0] >> 6) & 0x03)	/* Top 2 bits are area */
-		{
+		switch ((data[0] >> 6) & 0x03) {	/* Top 2 bits are area */
 		case 0:
 			area = 'P';
 			break;

--- a/scantool/diag_dtc.h
+++ b/scantool/diag_dtc.h
@@ -43,7 +43,7 @@ enum diag_dtc_protocol {
 //do not use *allocs or open handles in diag_dtc_init !
 void diag_dtc_init(void);
 
-char* diag_dtc_decode(uint8_t *data, int len,
+char *diag_dtc_decode(uint8_t *data, int len,
 	const char *vehicle, const char *ecu, enum diag_dtc_protocol protocol,
 	char *buf, const size_t bufsize);
 

--- a/scantool/diag_general.c
+++ b/scantool/diag_general.c
@@ -217,7 +217,7 @@ diag_freemsg(struct diag_msg *msg) {
 
 // diag_cks1: return simple 8-bit checksum of
 // [len] bytes at *data. Everybody needs this !
-uint8_t diag_cks1(const uint8_t * data, unsigned int len) {
+uint8_t diag_cks1(const uint8_t *data, unsigned int len) {
 	uint8_t rv=0;
 
 	while (len > 0) {
@@ -374,7 +374,7 @@ int diag_flmalloc(const char *name, const int line, void **pp, size_t s) {
 
 /* Add a string to array-of-strings (argv style)
 */
-char ** strlist_add(char ** list, const char * news, int elems) {
+char **strlist_add(char **list, const char *news, int elems) {
 	char **templist;
 	char *temp;
 
@@ -393,7 +393,7 @@ char ** strlist_add(char ** list, const char * news, int elems) {
 }
 
 /* Free argv-style list */
-void strlist_free(char ** list, int elems) {
+void strlist_free(char **list, int elems) {
 	if (!list) return;
 
 	while (elems > 0) {

--- a/scantool/diag_general.c
+++ b/scantool/diag_general.c
@@ -44,8 +44,7 @@ static int diag_initialized=0;
 
 //diag_init : should be called once before doing anything.
 //and call diag_end before terminating.
-int diag_init(void)	//returns 0 if normal exit
-{
+int diag_init(void) {	//returns 0 if normal exit
 	int rv;
 
 	if (diag_initialized)
@@ -95,8 +94,7 @@ int diag_end(void) {
 /** Message handling **/
 
 struct diag_msg *
-diag_allocmsg(size_t datalen)
-{
+diag_allocmsg(size_t datalen) {
 	struct diag_msg *newmsg;
 
 	if (datalen > DIAG_MAX_MSGLEN) {
@@ -131,8 +129,7 @@ diag_allocmsg(size_t datalen)
 
 /* Duplicate a message, and its contents including all chained messages. XXX nobody uses this !? */
 struct diag_msg *
-diag_dupmsg(struct diag_msg *msg)
-{
+diag_dupmsg(struct diag_msg *msg) {
 	struct diag_msg *newchain, *chain_last, *tmsg;
 
 	assert(msg != NULL);
@@ -168,8 +165,7 @@ diag_dupmsg(struct diag_msg *msg)
 /* Duplicate a single message, don't follow the chain */
 // (leave ->next undefined)
 struct diag_msg *
-diag_dupsinglemsg(struct diag_msg *msg)
-{
+diag_dupsinglemsg(struct diag_msg *msg) {
 	struct diag_msg *newmsg;
 
 	assert(msg != NULL);
@@ -196,8 +192,7 @@ diag_dupsinglemsg(struct diag_msg *msg)
 // it's easier to see the whole call stack leading to the failure.
 // Of course, not async safe.
 void
-diag_freemsg(struct diag_msg *msg)
-{
+diag_freemsg(struct diag_msg *msg) {
 	if (msg == NULL) return;
 
 	if (msg->next != NULL) {
@@ -235,8 +230,7 @@ uint8_t diag_cks1(const uint8_t * data, unsigned int len) {
 //diag_data_dump : print (len) bytes of uint8_t *data
 //to the specified FILE (stderr, etc.)
 void
-diag_data_dump(FILE *out, const void *data, size_t len)
-{
+diag_data_dump(FILE *out, const void *data, size_t len) {
 	const uint8_t *p = (const uint8_t *)data;
 	size_t i;
 	for (i=0; i<len; i++)
@@ -245,8 +239,7 @@ diag_data_dump(FILE *out, const void *data, size_t len)
 
 //smartcat() : make sure s1 is not too large, then strncat
 //it does NOT verify if *p1 is large enough !
-void smartcat(char *p1, const size_t s1, const char *p2 )
-{
+void smartcat(char *p1, const size_t s1, const char *p2 ) {
 	assert ( s1 > strlen(p1) + strlen (p2) + 1 ) ;
 	strncat(p1, p2, s1);
 }
@@ -334,8 +327,7 @@ diag_geterr(void) {
 // also checks for size !=0
 // ret 0 if ok
 int diag_flcalloc(const char *name, const int line,
-	void **pp, size_t n, size_t s)
-{
+	void **pp, size_t n, size_t s) {
 	void *p;
 
 	//sanity check: make sure we weren't given a null ptr
@@ -415,8 +407,7 @@ void strlist_free(char ** list, int elems) {
  * Message print out / debug routines
  */
 void
-diag_printmsg_header(FILE *fp, struct diag_msg *msg, bool timestamp, int msgnum)
-{
+diag_printmsg_header(FILE *fp, struct diag_msg *msg, bool timestamp, int msgnum) {
 	if (timestamp)
 		fprintf(fp, "%lu.%03lu: ",
 			msg->rxtime / 1000, msg->rxtime % 1000);
@@ -425,8 +416,7 @@ diag_printmsg_header(FILE *fp, struct diag_msg *msg, bool timestamp, int msgnum)
 }
 
 void
-diag_printmsg(FILE *fp, struct diag_msg *msg, bool timestamp)
-{
+diag_printmsg(FILE *fp, struct diag_msg *msg, bool timestamp) {
 	struct diag_msg *tmsg;
 	int i=0;
 

--- a/scantool/diag_l0.c
+++ b/scantool/diag_l0.c
@@ -66,7 +66,7 @@ void diag_l0_del(struct diag_l0_device *dl0d) {
 	return;
 }
 
-struct cfgi* diag_l0_getcfg(struct diag_l0_device *dl0d) {
+struct cfgi *diag_l0_getcfg(struct diag_l0_device *dl0d) {
 	if (!dl0d) return NULL;
 
 	if (dl0d->dl0->_getcfg) return dl0d->dl0->_getcfg(dl0d);

--- a/scantool/diag_l0.h
+++ b/scantool/diag_l0.h
@@ -30,8 +30,7 @@ struct diag_l0;
  * A "diag_l0_device" is a unique association between an l0 driver (diag_l0_dumb for instance)
  * and a hardware resource (serial port, file, etc.)
  */
-struct diag_l0_device
-{
+struct diag_l0_device {
 	void *l0_int;					/** Handle for internal L0 data */
 	const struct diag_l0 *dl0;		/** The L0 driver's diag_l0 */
 
@@ -40,8 +39,7 @@ struct diag_l0_device
 
 
 // diag_l0 : every diag_l0_???.c "driver" fills in one of these to describe itself.
-struct diag_l0
-{
+struct diag_l0 {
 	const char	*longname;	/* Useful textual name, unused at the moment */
 	const char	*shortname;	/* Short, unique text name for user interface */
 

--- a/scantool/diag_l0.h
+++ b/scantool/diag_l0.h
@@ -59,7 +59,7 @@ struct diag_l0 {
 	/* These are called from the "public funcs" listed below. */
 
 	int (*_new)(struct diag_l0_device *);
-	struct cfgi* (*_getcfg)(struct diag_l0_device *);
+	struct cfgi *(*_getcfg)(struct diag_l0_device *);
 	void (*_del)(struct diag_l0_device *);
 	int (*_open)(struct diag_l0_device *, int l1_proto);
 	void (*_close)(struct diag_l0_device *);
@@ -85,7 +85,7 @@ struct diag_l0_device *diag_l0_new(const char *shortname);
 
 /** Get linked-list of config items.
  * @return NULL if no items exist */
-struct cfgi* diag_l0_getcfg(struct diag_l0_device *);
+struct cfgi *diag_l0_getcfg(struct diag_l0_device *);
 
 
 /** Delete L0 driver instance.

--- a/scantool/diag_l0_br.c
+++ b/scantool/diag_l0_br.c
@@ -404,8 +404,7 @@ br_slowinit( struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in) {
 	if (rv == 1) {	/* 1 byte response, old type interface */
 		dev->dev_kb1 = buf[0];
 		dev->dev_kb2 = buf[0];
-	}
-	else {
+	} else {
 		dev->dev_kb1 = buf[0];
 		dev->dev_kb2 = buf[1];
 	}
@@ -450,8 +449,7 @@ br_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in) {
 		if ((dev->dev_features & BR_FEATURE_FASTINIT) == 0) {
 			/* Fast init Not supported */
 			rv = DIAG_ERR_INIT_NOTSUPP;
-		}
-		else {
+		} else {
 			/* Fastinit done on 1st TX */
 			dev->dev_state = BR_STATE_KWP_FASTINIT;
 			rv = 0;

--- a/scantool/diag_l0_br.c
+++ b/scantool/diag_l0_br.c
@@ -150,7 +150,7 @@ static void br_del(struct diag_l0_device *dl0d) {
 	return;
 }
 
-static struct cfgi* br_getcfg(struct diag_l0_device *dl0d) {
+static struct cfgi *br_getcfg(struct diag_l0_device *dl0d) {
 	struct br_device *dev;
 	if (dl0d==NULL) return diag_pseterr(DIAG_ERR_BADCFG);
 

--- a/scantool/diag_l0_dumb.c
+++ b/scantool/diag_l0_dumb.c
@@ -40,8 +40,7 @@
 #include "diag_l0.h"
 #include "diag_l1.h"
 
-struct dumb_device
-{
+struct dumb_device {
 	int	protocol;	//set in dumb_open with specified iProtocol
 	struct	diag_serial_settings serial;
 
@@ -125,8 +124,7 @@ static void dumb_close(struct diag_l0_device *dl0d);
  * variables etc
  */
 static int
-dumb_init(void)
-{
+dumb_init(void) {
 	return 0;
 }
 
@@ -189,8 +187,7 @@ static struct cfgi* dumb_getcfg(struct diag_l0_device *dl0d) {
 }
 
 
-static int dumb_open(struct diag_l0_device *dl0d, int iProtocol)
-{
+static int dumb_open(struct diag_l0_device *dl0d, int iProtocol) {
 	struct dumb_device *dev;
 	int dumbopts;
 
@@ -239,8 +236,7 @@ static int dumb_open(struct diag_l0_device *dl0d, int iProtocol)
 
 //dumb_close : close TTY handle.
 static void
-dumb_close(struct diag_l0_device *dl0d)
-{
+dumb_close(struct diag_l0_device *dl0d) {
 	if (!dl0d) return;
 
 	struct dumb_device *dev = dl0d->l0_int;
@@ -264,8 +260,7 @@ dumb_close(struct diag_l0_device *dl0d)
  * Exceptionally we dont diag_iseterr on return since _initbus() takes care of that.
  */
 static int
-dumb_fastinit(struct diag_l0_device *dl0d)
-{
+dumb_fastinit(struct diag_l0_device *dl0d) {
 	struct dumb_device *dev = dl0d->l0_int;
 	int rv=0;
 	uint8_t cbuf[MAXRBUF];
@@ -345,8 +340,7 @@ dumb_fastinit(struct diag_l0_device *dl0d)
 // Returns after stop bit is finished + time for diag_tty_read to flush echo. (max 20ms) (NOT the sync byte!)
 
 static void
-dumb_Lline(struct diag_l0_device *dl0d, uint8_t ecuaddr)
-{
+dumb_Lline(struct diag_l0_device *dl0d, uint8_t ecuaddr) {
 	/*
 	 * The bus has been high for w0 ms already, now send the
 	 * 8 bit ecuaddr at 5 baud LSB first
@@ -416,8 +410,7 @@ dumb_Lline(struct diag_l0_device *dl0d, uint8_t ecuaddr)
  */
 static int
 dumb_slowinit(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in,
-	struct dumb_device *dev)
-{
+	struct dumb_device *dev) {
 	uint8_t cbuf[10];
 	int rv;
 	unsigned int tout;
@@ -578,8 +571,7 @@ dumb_slowinit(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in,
  * responsible for waiting W5, W0 or Tidle before calling initbus().
  */
 static int
-dumb_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in)
-{
+dumb_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in) {
 	int rv = DIAG_ERR_INIT_NOTSUPP;
 
 	struct dumb_device *dev;
@@ -637,8 +629,7 @@ static int dumb_iflush(struct diag_l0_device *dl0d) {
 static int
 dumb_send(struct diag_l0_device *dl0d,
 UNUSED(const char *subinterface),
-const void *data, size_t len)
-{
+const void *data, size_t len) {
 	/*
 	 * This will be called byte at a time unless P4 timing parameter is zero
 	 * as the L1 code that called this will be adding the P4 gap between
@@ -675,8 +666,7 @@ const void *data, size_t len)
 static int
 dumb_recv(struct diag_l0_device *dl0d,
 UNUSED(const char *subinterface),
-void *data, size_t len, unsigned int timeout)
-{
+void *data, size_t len, unsigned int timeout) {
 	int rv;
 	struct dumb_device *dev = dl0d->l0_int;
 
@@ -708,8 +698,7 @@ void *data, size_t len, unsigned int timeout)
  */
 static int
 dumb_setspeed(struct diag_l0_device *dl0d,
-const struct diag_serial_settings *pset)
-{
+const struct diag_serial_settings *pset) {
 	struct dumb_device *dev;
 
 	dev = (struct dumb_device *)dl0d->l0_int;
@@ -721,8 +710,7 @@ const struct diag_serial_settings *pset)
 
 
 static uint32_t
-dumb_getflags(struct diag_l0_device *dl0d)
-{
+dumb_getflags(struct diag_l0_device *dl0d) {
 	struct dumb_device *dev;
 	int flags=0;
 

--- a/scantool/diag_l0_dumb.c
+++ b/scantool/diag_l0_dumb.c
@@ -178,7 +178,7 @@ static void dumb_del(struct diag_l0_device *dl0d) {
 	return;
 }
 
-static struct cfgi* dumb_getcfg(struct diag_l0_device *dl0d) {
+static struct cfgi *dumb_getcfg(struct diag_l0_device *dl0d) {
 	struct dumb_device *dev;
 	if (dl0d==NULL) return diag_pseterr(DIAG_ERR_BADCFG);
 

--- a/scantool/diag_l0_dumbtest.c
+++ b/scantool/diag_l0_dumbtest.c
@@ -503,7 +503,7 @@ static void dt_del(struct diag_l0_device *dl0d) {
 	return;
 }
 
-static struct cfgi* dt_getcfg(struct diag_l0_device *dl0d) {
+static struct cfgi *dt_getcfg(struct diag_l0_device *dl0d) {
 	struct dt_device *dev;
 	if (dl0d==NULL) return diag_pseterr(DIAG_ERR_BADCFG);
 

--- a/scantool/diag_l0_dumbtest.c
+++ b/scantool/diag_l0_dumbtest.c
@@ -23,8 +23,7 @@
 #include "diag_l0.h"
 #include "diag_l1.h"
 
-struct dt_device
-{
+struct dt_device {
 	int protocol;	//set in dt_open with specified iProtocol
 	struct diag_serial_settings serial;
 
@@ -104,8 +103,7 @@ const void *data, size_t len);
  * variables etc
  */
 static int
-dt_init(void)
-{
+dt_init(void) {
 	/* Global init flag */
 	static int dt_initdone=0;
 
@@ -518,8 +516,7 @@ static struct cfgi* dt_getcfg(struct diag_l0_device *dl0d) {
  * Open the diagnostic device, returns a file descriptor
  * records original state of term interface so we can restore later
  */
-static int dt_open(struct diag_l0_device *dl0d, int testnum)
-{
+static int dt_open(struct diag_l0_device *dl0d, int testnum) {
 	struct dt_device *dev;
 	struct diag_serial_settings pset;
 	int dumbopts;
@@ -638,8 +635,7 @@ static int dt_open(struct diag_l0_device *dl0d, int testnum)
 
 
 static void
-dt_close(UNUSED(struct diag_l0_device *dl0d))
-{
+dt_close(UNUSED(struct diag_l0_device *dl0d)) {
 	return;
 }
 
@@ -654,8 +650,7 @@ dt_close(UNUSED(struct diag_l0_device *dl0d))
 static int
 dt_send(struct diag_l0_device *dl0d,
 UNUSED(const char *subinterface),
-const void *data, size_t len)
-{
+const void *data, size_t len) {
 	struct dt_device *dev = dl0d->l0_int;
 
 	/*
@@ -693,8 +688,7 @@ const void *data, size_t len)
 static int
 dt_recv(struct diag_l0_device *dl0d,
 UNUSED(const char *subinterface),
-UNUSED(void *data), size_t len, unsigned int timeout)
-{
+UNUSED(void *data), size_t len, unsigned int timeout) {
 	fprintf(stderr,
 		FLFMT "link %p recv upto %ld bytes timeout %u; doing nothing.\n",
 		FL, (void *)dl0d, (long)len, timeout);
@@ -707,8 +701,7 @@ UNUSED(void *data), size_t len, unsigned int timeout)
  */
 static int
 dt_setspeed(struct diag_l0_device *dl0d,
-const struct diag_serial_settings *pset)
-{
+const struct diag_serial_settings *pset) {
 	struct dt_device *dev;
 
 	dev = (struct dt_device *)(dl0d->l0_int);
@@ -720,8 +713,7 @@ const struct diag_serial_settings *pset)
 
 
 static uint32_t
-dt_getflags(UNUSED(struct diag_l0_device *dl0d))
-{
+dt_getflags(UNUSED(struct diag_l0_device *dl0d)) {
 	return DIAG_L1_HALFDUPLEX;
 }
 

--- a/scantool/diag_l0_elm.c
+++ b/scantool/diag_l0_elm.c
@@ -76,18 +76,18 @@ struct elm_device {
 
 
 // possible error messages returned by the ELM IC
-static const char * elm323_errors[] = {"BUS BUSY", "FB ERROR", "DATA ERROR", "<DATA ERROR", "NO DATA", "?", NULL};
+static const char *elm323_errors[] = {"BUS BUSY", "FB ERROR", "DATA ERROR", "<DATA ERROR", "NO DATA", "?", NULL};
 
-static const char * elm327_errors[] = {"BUS BUSY", "FB ERROR", "DATA ERROR", "<DATA ERROR", "NO DATA", "?",
+static const char *elm327_errors[] = {"BUS BUSY", "FB ERROR", "DATA ERROR", "<DATA ERROR", "NO DATA", "?",
 						"ACT ALERT", "BUFFER FULL", "BUS ERROR", "CAN ERROR", "LP ALERT",
 						"LV RESET", "<RX ERROR", "STOPPED", "UNABLE TO CONNECT", "ERR", NULL};
 
 // authentic VS clone identification strings.
 // I know of no elm323 clones. 327 clones may not support some commands (atfi, atsi, atkw) and thus need fallback methods
-static const char * elm323_official[] = {"2.0",NULL};	//authentic 323 firmware versions, possibly incomplete list
-static const char * elm323_clones[] = {NULL};	//known cloned versions
-static const char * elm327_official[] = {"1.0a", "1.0", "1.1", "1.2a", "1.2", "1.3a", "1.3", "1.4b", "2.0", NULL};
-static const char * elm327_clones[] = {"1.4", "1.4a", "1.5a", "1.5", "2.1", NULL};
+static const char *elm323_official[] = {"2.0",NULL};	//authentic 323 firmware versions, possibly incomplete list
+static const char *elm323_clones[] = {NULL};	//known cloned versions
+static const char *elm327_official[] = {"1.0a", "1.0", "1.1", "1.2a", "1.2", "1.3a", "1.3", "1.4b", "2.0", NULL};
+static const char *elm327_clones[] = {"1.4", "1.4a", "1.5a", "1.5", "2.1", NULL};
 
 // baud rates for host to elm32x communication. Start with user-specified speed, then try common values
 #define ELM_CUSTOMSPEED ((unsigned) -1)
@@ -127,7 +127,7 @@ elm_init(void) {
 	return 0;
 }
 
-int elm_new(struct diag_l0_device * dl0d) {
+int elm_new(struct diag_l0_device *dl0d) {
 	struct elm_device *dev;
 
 	assert(dl0d);
@@ -156,7 +156,7 @@ int elm_new(struct diag_l0_device * dl0d) {
 	return 0;
 }
 
-struct cfgi* elm_getcfg(struct diag_l0_device *dl0d) {
+struct cfgi *elm_getcfg(struct diag_l0_device *dl0d) {
 	struct elm_device *dev;
 	if (dl0d==NULL) return diag_pseterr(DIAG_ERR_BADCFG);
 
@@ -210,9 +210,9 @@ elm_close(struct diag_l0_device *dl0d) {
 //elm_parse_errors : look for known error messages in the reply.
 // return any match or NULL if nothing found.
 // data[] must be \0-terminated !
-static const char * elm_parse_errors(struct diag_l0_device *dl0d, uint8_t *data) {
+static const char *elm_parse_errors(struct diag_l0_device *dl0d, uint8_t *data) {
 	struct elm_device *dev;
-	const char ** elm_errors;	//just used to select between the 2 error lists
+	const char **elm_errors;	//just used to select between the 2 error lists
 	int i;
 
 	dev = (struct elm_device *) dl0d->l0_int;
@@ -359,8 +359,8 @@ elm_open(struct diag_l0_device *dl0d, int iProtocol) {
 	const uint8_t *buf;
 	uint8_t rxbuf[ELM_BUFSIZE];
 
-	const char ** elm_official;
-	const char ** elm_clones;	//point to elm323_ or elm327_ clone and official version string lists
+	const char **elm_official;
+	const char **elm_clones;	//point to elm323_ or elm327_ clone and official version string lists
 
 	assert(dl0d);
 	dev = dl0d->l0_int;
@@ -596,7 +596,7 @@ elm_open(struct diag_l0_device *dl0d, int iProtocol) {
  */
 static int
 elm_fastinit(struct diag_l0_device *dl0d) {
-	uint8_t * cmds= (uint8_t *) "ATFI\x0D";
+	uint8_t *cmds= (uint8_t *) "ATFI\x0D";
 
 	if (diag_l0_debug & DIAG_DEBUG_PROTO)
 		fprintf(stderr, FLFMT "ELM forced fastinit...\n", FL);
@@ -612,7 +612,7 @@ elm_fastinit(struct diag_l0_device *dl0d) {
 
 static int
 elm_slowinit(struct diag_l0_device *dl0d) {
-	uint8_t * cmds=(uint8_t *)"ATSI\x0D";
+	uint8_t *cmds=(uint8_t *)"ATSI\x0D";
 
 	if (diag_l0_debug & DIAG_DEBUG_PROTO) {
 		fprintf(stderr, FLFMT "ELM forced slowinit...\n", FL);

--- a/scantool/diag_l0_elm.c
+++ b/scantool/diag_l0_elm.c
@@ -76,22 +76,22 @@ struct elm_device {
 
 
 // possible error messages returned by the ELM IC
-static const char * elm323_errors[]={"BUS BUSY", "FB ERROR", "DATA ERROR", "<DATA ERROR", "NO DATA", "?", NULL};
+static const char * elm323_errors[] = {"BUS BUSY", "FB ERROR", "DATA ERROR", "<DATA ERROR", "NO DATA", "?", NULL};
 
-static const char * elm327_errors[]={"BUS BUSY", "FB ERROR", "DATA ERROR", "<DATA ERROR", "NO DATA", "?",
+static const char * elm327_errors[] = {"BUS BUSY", "FB ERROR", "DATA ERROR", "<DATA ERROR", "NO DATA", "?",
 						"ACT ALERT", "BUFFER FULL", "BUS ERROR", "CAN ERROR", "LP ALERT",
 						"LV RESET", "<RX ERROR", "STOPPED", "UNABLE TO CONNECT", "ERR", NULL};
 
 // authentic VS clone identification strings.
 // I know of no elm323 clones. 327 clones may not support some commands (atfi, atsi, atkw) and thus need fallback methods
-static const char * elm323_official[]={"2.0",NULL};	//authentic 323 firmware versions, possibly incomplete list
-static const char * elm323_clones[]={NULL};	//known cloned versions
-static const char * elm327_official[]={"1.0a", "1.0", "1.1", "1.2a", "1.2", "1.3a", "1.3", "1.4b", "2.0", NULL};
-static const char * elm327_clones[]={"1.4", "1.4a", "1.5a", "1.5", "2.1", NULL};
+static const char * elm323_official[] = {"2.0",NULL};	//authentic 323 firmware versions, possibly incomplete list
+static const char * elm323_clones[] = {NULL};	//known cloned versions
+static const char * elm327_official[] = {"1.0a", "1.0", "1.1", "1.2a", "1.2", "1.3a", "1.3", "1.4b", "2.0", NULL};
+static const char * elm327_clones[] = {"1.4", "1.4a", "1.5a", "1.5", "2.1", NULL};
 
 // baud rates for host to elm32x communication. Start with user-specified speed, then try common values
 #define ELM_CUSTOMSPEED ((unsigned) -1)
-static const unsigned elm_speeds[]={ELM_CUSTOMSPEED, 38400, 9600, 115200, 0};
+static const unsigned elm_speeds[] = {ELM_CUSTOMSPEED, 38400, 9600, 115200, 0};
 
 
 extern const struct diag_l0 diag_l0_elm;
@@ -113,8 +113,7 @@ static void elm_close(struct diag_l0_device *dl0d);
  * variables etc
  */
 static int
-elm_init(void)
-{
+elm_init(void) {
 	static int elm_initdone=0;
 
 	if (elm_initdone)
@@ -183,8 +182,7 @@ void elm_del(struct diag_l0_device *dl0d) {
 
 
 static void
-elm_close(struct diag_l0_device *dl0d)
-{
+elm_close(struct diag_l0_device *dl0d) {
 	uint8_t buf[]="ATPC\x0D";
 	struct elm_device *dev;
 
@@ -246,8 +244,7 @@ static const char * elm_parse_errors(struct diag_l0_device *dl0d, uint8_t *data)
 //		(prompt_good && ATZ or ATKW command was sent) , since response doesn't contain "OK" for ATZ or ATKW.
 //elm_sendcmd should not be called from outside diag_l0_elm.c.
 static int
-elm_sendcmd(struct diag_l0_device *dl0d, const uint8_t *data, size_t len, unsigned int timeout, uint8_t *resp)
-{
+elm_sendcmd(struct diag_l0_device *dl0d, const uint8_t *data, size_t len, unsigned int timeout, uint8_t *resp) {
 	//note : we better not request (len == (size_t) -1) bytes ! The casts between ssize_t and size_t are
 	// "muddy" in here
 	//ssize_t xferd;
@@ -355,8 +352,7 @@ elm_sendcmd(struct diag_l0_device *dl0d, const uint8_t *data, size_t len, unsign
  * ELM settings used : no echo (E0), headers on (H1), linefeeds off (L0), mem off (M0)
  */
 static int
-elm_open(struct diag_l0_device *dl0d, int iProtocol)
-{
+elm_open(struct diag_l0_device *dl0d, int iProtocol) {
 	int i,rv;
 	struct elm_device *dev;
 	struct diag_serial_settings sset;
@@ -599,8 +595,7 @@ elm_open(struct diag_l0_device *dl0d, int iProtocol)
  * Unsupported by some (all?) clones !! (they handle the init internally, on demand)
  */
 static int
-elm_fastinit(struct diag_l0_device *dl0d)
-{
+elm_fastinit(struct diag_l0_device *dl0d) {
 	uint8_t * cmds= (uint8_t *) "ATFI\x0D";
 
 	if (diag_l0_debug & DIAG_DEBUG_PROTO)
@@ -616,8 +611,7 @@ elm_fastinit(struct diag_l0_device *dl0d)
 
 
 static int
-elm_slowinit(struct diag_l0_device *dl0d)
-{
+elm_slowinit(struct diag_l0_device *dl0d) {
 	uint8_t * cmds=(uint8_t *)"ATSI\x0D";
 
 	if (diag_l0_debug & DIAG_DEBUG_PROTO) {
@@ -638,13 +632,12 @@ elm_slowinit(struct diag_l0_device *dl0d)
 // non-OBD ECUs may not work with this. ELM clones suck...
 // TODO : add argument to allow either a 01 00 request (SID1 PID0, J1979) or 3E (iso14230 TesterPresent) request to force init.
 static int
-elm_bogusinit(struct diag_l0_device *dl0d, unsigned int timeout)
-{
+elm_bogusinit(struct diag_l0_device *dl0d, unsigned int timeout) {
 	int rv;
 	struct elm_device *dev;
 	uint8_t buf[MAXRBUF];
-	uint8_t generic_data[]={0x01,0x00}; // J1979 request only
-	uint8_t iso9141_data[]={0x68,0x6a,0xf1,0x01,0x00}; // with ISO9141 hdr
+	uint8_t generic_data[] = {0x01,0x00}; // J1979 request only
+	uint8_t iso9141_data[] = {0x68,0x6a,0xf1,0x01,0x00}; // with ISO9141 hdr
 	const char *err_str;
 
 	dev = dl0d->l0_int;
@@ -693,8 +686,7 @@ elm_bogusinit(struct diag_l0_device *dl0d, unsigned int timeout)
 
 // set wakeup message
 static int
-elm_updatewm(struct diag_l0_device *dl0d)
-{
+elm_updatewm(struct diag_l0_device *dl0d) {
 	struct elm_device *dev;
 	uint8_t wm[18];
 
@@ -712,8 +704,7 @@ elm_updatewm(struct diag_l0_device *dl0d)
  * ret 0 if ok
  */
 static int
-elm_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in)
-{
+elm_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in) {
 	const uint8_t *buf;
 	int rv = DIAG_ERR_INIT_NOTSUPP;
 	unsigned int timeout=0;	//for bogus init
@@ -923,8 +914,7 @@ static int elm_purge(struct diag_l0_device *dl0d) {
 
 static int
 elm_send(struct diag_l0_device *dl0d,
-	UNUSED(const char *subinterface), const void *data, size_t len)
-{
+	UNUSED(const char *subinterface), const void *data, size_t len) {
 	uint8_t buf[ELM_BUFSIZE];
 	struct elm_device *dev = dl0d->l0_int;
 	//ssize_t xferd;
@@ -1019,8 +1009,7 @@ elm_send(struct diag_l0_device *dl0d,
  */
 static int
 elm_recv(struct diag_l0_device *dl0d,
-	UNUSED(const char *subinterface), void *data, size_t len, unsigned int timeout)
-{
+	UNUSED(const char *subinterface), void *data, size_t len, unsigned int timeout) {
 	int rv, xferd;
 	struct elm_device *dev = dl0d->l0_int;
 	uint8_t rxbuf[3*MAXRBUF +1];	//I think some hotdog code in L2/L3 calls _recv with MAXRBUF so this needs to be huge.
@@ -1165,8 +1154,7 @@ static int elm_setwm(struct diag_l0_device *dl0d, struct diag_msg *pmsg) {
 
 
 static uint32_t
-elm_getflags(struct diag_l0_device *dl0d)
-{
+elm_getflags(struct diag_l0_device *dl0d) {
 
 	struct elm_device *dev;
 	uint32_t flags=0;

--- a/scantool/diag_l0_me.c
+++ b/scantool/diag_l0_me.c
@@ -381,7 +381,7 @@ static void muleng_del(struct diag_l0_device *dl0d) {
 	return;
 }
 
-static struct cfgi* muleng_getcfg(struct diag_l0_device *dl0d) {
+static struct cfgi *muleng_getcfg(struct diag_l0_device *dl0d) {
 	struct muleng_device *dev;
 	if (dl0d==NULL) return diag_pseterr(DIAG_ERR_BADCFG);
 

--- a/scantool/diag_l0_me.c
+++ b/scantool/diag_l0_me.c
@@ -230,8 +230,7 @@ j1850_crc(uint8_t *msg_buf, int nbytes) {
 				else
 					poly=0x1c;
 				crc_reg= ( (crc_reg << 1) | 1) ^ poly;
-			}
-			else {		// case for new bit = 0
+			} else {		// case for new bit = 0
 				poly=0;
 				if (crc_reg & 0x80)
 					poly=0x1d;
@@ -737,8 +736,7 @@ void *data, size_t len, unsigned int timeout) {
 			pdata[1] = dev->dev_kb2;
 			dev->dev_state = MULENG_STATE_OPEN;
 			return 2;
-		}
-		else if (len == 1) {
+		} else if (len == 1) {
 			*pdata = dev->dev_kb1;
 			dev->dev_state = MULENG_STATE_KWP_SENDKB2;
 			return 1;

--- a/scantool/diag_l0_sim.c
+++ b/scantool/diag_l0_sim.c
@@ -68,8 +68,7 @@ const char *simfile_default=DB_FILE;	//default filename
 
 
 // ECU responses linked list:
-struct sim_ecu_response
-{
+struct sim_ecu_response {
 	char *text; // unparsed text for the response!
 	uint8_t *data; // parsed final response.
 	uint8_t len; // final response length.
@@ -77,8 +76,7 @@ struct sim_ecu_response
 };
 
 /* Internal state (struct diag_l0_device->l0_int) */
-struct sim_device
-{
+struct sim_device {
 	int protocol;
 	FILE* fp; // DB file pointer.
 	// Configuration variables.
@@ -126,8 +124,7 @@ static void sim_close(struct diag_l0_device *dl0d);
 
 // Allocates one new ecu response and fills it with given text.
 struct sim_ecu_response*
-sim_new_ecu_response_txt(const char* text)
-{
+sim_new_ecu_response_txt(const char* text) {
 	struct sim_ecu_response *resp;
 	int rv;
 
@@ -154,8 +151,7 @@ sim_new_ecu_response_txt(const char* text)
 // Allocates one new ecu response and fills it with given data.
 // (not used yet, here for "just in case")
 struct sim_ecu_response*
-sim_new_ecu_response_bin(const uint8_t* data, const uint8_t len)
-{
+sim_new_ecu_response_bin(const uint8_t* data, const uint8_t len) {
 	struct sim_ecu_response *resp;
 
 	if (diag_calloc(&resp, 1))
@@ -179,8 +175,7 @@ sim_new_ecu_response_bin(const uint8_t* data, const uint8_t len)
 
 // Frees an ecu response and returns the next one in the list.
 struct sim_ecu_response*
-sim_free_ecu_response(struct sim_ecu_response** resp)
-{
+sim_free_ecu_response(struct sim_ecu_response** resp) {
 	struct sim_ecu_response* next_resp = NULL;
 
 	if (resp && *resp) {
@@ -203,8 +198,7 @@ sim_free_ecu_response(struct sim_ecu_response** resp)
 
 
 // Frees all responses from the given one until the end of the list.
-void sim_free_ecu_responses(struct sim_ecu_response** resp_pp)
-{
+void sim_free_ecu_responses(struct sim_ecu_response** resp_pp) {
 	struct sim_ecu_response** temp_resp_pp = resp_pp;
 	uint8_t count = 0;
 
@@ -222,8 +216,7 @@ void sim_free_ecu_responses(struct sim_ecu_response** resp_pp)
 }
 
 // for debug purposes.
-void sim_dump_ecu_responses(struct sim_ecu_response* resp_p)
-{
+void sim_dump_ecu_responses(struct sim_ecu_response* resp_p) {
 	struct sim_ecu_response* tresp;
 	uint8_t count = 0;
 
@@ -237,8 +230,7 @@ void sim_dump_ecu_responses(struct sim_ecu_response* resp_p)
 
 
 // Builds a list of responses for a request, by finding them in the DB file.
-void sim_find_responses(struct sim_ecu_response** resp_pp, FILE* fp, const uint8_t* data, const uint8_t len)
-{
+void sim_find_responses(struct sim_ecu_response** resp_pp, FILE* fp, const uint8_t* data, const uint8_t len) {
 #define TAG_REQUEST "RQ"
 #define TAG_RESPONSE "RP"
 #define VALUE_DONTCARE "XXXX"
@@ -264,8 +256,7 @@ void sim_find_responses(struct sim_ecu_response** resp_pp, FILE* fp, const uint8
 	// search for the given request.
 	while (!request_found && !end_responses) {
 		// get a line from DB file.
-		if (fgets(line_buf, sizeof(line_buf), fp) == NULL)
-		{
+		if (fgets(line_buf, sizeof(line_buf), fp) == NULL) {
 			// EOF reached.
 			break;
 		}
@@ -345,8 +336,7 @@ void sim_find_responses(struct sim_ecu_response** resp_pp, FILE* fp, const uint8
 
 // Returns a value between 0x00 and 0xFF calculated as the trigonometric
 // sine of the current system time (with a period of one second).
-uint8_t sine1(UNUSED(uint8_t *data), UNUSED(uint8_t pos))
-{
+uint8_t sine1(UNUSED(uint8_t *data), UNUSED(uint8_t pos)) {
 	unsigned long now=diag_os_getms();
 	//sin() returns a float between -1.0 and 1.0
 	return (uint8_t) (0x7F * sin(now * 6.283185 / 1000));
@@ -354,15 +344,13 @@ uint8_t sine1(UNUSED(uint8_t *data), UNUSED(uint8_t pos))
 
 // Returns a value between 0x00 and 0xFF directly proportional
 // to the value of the current system time (with a period of one second).
-uint8_t sawtooth1(UNUSED(uint8_t *data), UNUSED(uint8_t pos))
-{
+uint8_t sawtooth1(UNUSED(uint8_t *data), UNUSED(uint8_t pos)) {
 	unsigned long now=diag_os_getms();
 	return (uint8_t) (0xFF * (now % 1000));
 }
 
 // Returns a value copied from the specified position in the request.
-uint8_t requestbyten(UNUSED(uint8_t *data), char *s, uint8_t req[])
-{
+uint8_t requestbyten(UNUSED(uint8_t *data), char *s, uint8_t req[]) {
 	int index;
 	bool increment = 0;
 	bool bogus = 0;
@@ -395,8 +383,7 @@ uint8_t requestbyten(UNUSED(uint8_t *data), char *s, uint8_t req[])
 
 // Parses a response's text to data.
 // Replaces special tokens with function results. This mangles resp_p->text, which shouldn't be a problem
-void sim_parse_response(struct sim_ecu_response* resp_p, uint8_t req[])
-{
+void sim_parse_response(struct sim_ecu_response* resp_p, uint8_t req[]) {
 #define TOKEN_SINE1	 "sin1"
 #define TOKEN_SAWTOOTH1 "swt1"
 #define TOKEN_ISO9141CS "cks1"
@@ -449,8 +436,7 @@ void sim_parse_response(struct sim_ecu_response* resp_p, uint8_t req[])
 
 // Reads the configuration options from the file.
 // Stores them in globals.
-void sim_read_cfg(struct sim_device *dev)
-{
+void sim_read_cfg(struct sim_device *dev) {
 	FILE *fp = dev->fp;
 	char *p; // temp string pointer.
 	char line_buf[21]; // 20 chars generally enough for a config token.
@@ -524,8 +510,7 @@ void sim_read_cfg(struct sim_device *dev)
 
 // Initializes the simulator.
 static int
-sim_init(void)
-{
+sim_init(void) {
 	return 0;
 }
 
@@ -570,8 +555,7 @@ sim_del(struct diag_l0_device * dl0d) {
 
 // Opens the simulator DB file
 int
-sim_open(struct diag_l0_device *dl0d, int iProtocol)
-{
+sim_open(struct diag_l0_device *dl0d, int iProtocol) {
 	struct sim_device *dev;
 	const char *simfile;
 
@@ -612,8 +596,7 @@ sim_open(struct diag_l0_device *dl0d, int iProtocol)
 
 // Closes the simulator DB file; cleanup after _sim_open()
 static void
-sim_close(struct diag_l0_device *dl0d)
-{
+sim_close(struct diag_l0_device *dl0d) {
 	assert(dl0d != NULL);
 	//if (!dl0d) return;
 
@@ -640,8 +623,7 @@ sim_close(struct diag_l0_device *dl0d)
 
 // Simulates the bus initialization.
 static int
-sim_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in)
-{
+sim_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in) {
 	struct sim_device *dev;
 	uint8_t synch_patt[1];
 	const uint8_t sim_break = 0x00;
@@ -690,8 +672,7 @@ sim_initbus(struct diag_l0_device *dl0d, struct diag_l1_initbus_args *in)
 static int
 sim_send(struct diag_l0_device *dl0d,
 		UNUSED(const char *subinterface),
-		 const void *data, const size_t len)
-{
+		 const void *data, const size_t len) {
 	struct sim_device * dev = dl0d->l0_int;
 
 	if (len <= 0)
@@ -735,8 +716,7 @@ sim_send(struct diag_l0_device *dl0d,
 static int
 sim_recv(struct diag_l0_device *dl0d,
 		UNUSED(const char *subinterface),
-		void *data, size_t len, unsigned int timeout)
-{
+		void *data, size_t len, unsigned int timeout) {
 	size_t xferd;
 	struct sim_ecu_response* resp_p = NULL;
 	struct sim_device * dev = dl0d->l0_int;
@@ -782,8 +762,7 @@ sim_recv(struct diag_l0_device *dl0d,
 // The simulator doesn't need half-duplex or
 // P4 timing, and implements all types of init.
 static uint32_t
-sim_getflags(struct diag_l0_device *dl0d)
-{
+sim_getflags(struct diag_l0_device *dl0d) {
 	struct sim_device * dev = dl0d->l0_int;
 	int ret;
 
@@ -841,8 +820,7 @@ static int sim_ioctl(struct diag_l0_device *dl0d, unsigned cmd, void *data) {
 // and pointers to functions.
 // Like any simulator, it "implements" all protocols
 // (it only depends on the content of the DB file).
-const struct diag_l0 diag_l0_sim =
-{
+const struct diag_l0 diag_l0_sim = {
 	"Car Simulator interface",
 	"CARSIM",
 	DIAG_L1_J1850_VPW | DIAG_L1_J1850_PWM | DIAG_L1_ISO9141 | DIAG_L1_ISO14230 | DIAG_L1_RAW,

--- a/scantool/diag_l0_sim.c
+++ b/scantool/diag_l0_sim.c
@@ -72,13 +72,13 @@ struct sim_ecu_response {
 	char *text; // unparsed text for the response!
 	uint8_t *data; // parsed final response.
 	uint8_t len; // final response length.
-	struct sim_ecu_response* next;
+	struct sim_ecu_response *next;
 };
 
 /* Internal state (struct diag_l0_device->l0_int) */
 struct sim_device {
 	int protocol;
-	FILE* fp; // DB file pointer.
+	FILE *fp; // DB file pointer.
 	// Configuration variables.
 	// These affect the kind of flags we should return.
 	// This makes the simulator configurable towards using
@@ -95,7 +95,7 @@ struct sim_device {
 	struct cfgi simfile;
 
 	uint8_t sim_last_ecu_request[255];	// Copy of most recent request.
-	struct sim_ecu_response* sim_last_ecu_responses;	// For keeping all the responses to the last request.
+	struct sim_ecu_response *sim_last_ecu_responses;	// For keeping all the responses to the last request.
 };
 
 
@@ -123,8 +123,8 @@ static void sim_close(struct diag_l0_device *dl0d);
 
 
 // Allocates one new ecu response and fills it with given text.
-struct sim_ecu_response*
-sim_new_ecu_response_txt(const char* text) {
+struct sim_ecu_response
+*sim_new_ecu_response_txt(const char *text) {
 	struct sim_ecu_response *resp;
 	int rv;
 
@@ -150,8 +150,8 @@ sim_new_ecu_response_txt(const char* text) {
 
 // Allocates one new ecu response and fills it with given data.
 // (not used yet, here for "just in case")
-struct sim_ecu_response*
-sim_new_ecu_response_bin(const uint8_t* data, const uint8_t len) {
+struct sim_ecu_response
+*sim_new_ecu_response_bin(const uint8_t *data, const uint8_t len) {
 	struct sim_ecu_response *resp;
 
 	if (diag_calloc(&resp, 1))
@@ -174,8 +174,8 @@ sim_new_ecu_response_bin(const uint8_t* data, const uint8_t len) {
 }
 
 // Frees an ecu response and returns the next one in the list.
-struct sim_ecu_response*
-sim_free_ecu_response(struct sim_ecu_response** resp) {
+struct sim_ecu_response
+*sim_free_ecu_response(struct sim_ecu_response **resp) {
 	struct sim_ecu_response* next_resp = NULL;
 
 	if (resp && *resp) {
@@ -198,8 +198,8 @@ sim_free_ecu_response(struct sim_ecu_response** resp) {
 
 
 // Frees all responses from the given one until the end of the list.
-void sim_free_ecu_responses(struct sim_ecu_response** resp_pp) {
-	struct sim_ecu_response** temp_resp_pp = resp_pp;
+void sim_free_ecu_responses(struct sim_ecu_response **resp_pp) {
+	struct sim_ecu_response **temp_resp_pp = resp_pp;
 	uint8_t count = 0;
 
 	if ((resp_pp==NULL) || (*resp_pp==NULL))
@@ -216,8 +216,8 @@ void sim_free_ecu_responses(struct sim_ecu_response** resp_pp) {
 }
 
 // for debug purposes.
-void sim_dump_ecu_responses(struct sim_ecu_response* resp_p) {
-	struct sim_ecu_response* tresp;
+void sim_dump_ecu_responses(struct sim_ecu_response *resp_p) {
+	struct sim_ecu_response *tresp;
 	uint8_t count = 0;
 
 	LL_FOREACH(resp_p, tresp) {
@@ -230,7 +230,7 @@ void sim_dump_ecu_responses(struct sim_ecu_response* resp_p) {
 
 
 // Builds a list of responses for a request, by finding them in the DB file.
-void sim_find_responses(struct sim_ecu_response** resp_pp, FILE* fp, const uint8_t* data, const uint8_t len) {
+void sim_find_responses(struct sim_ecu_response **resp_pp, FILE *fp, const uint8_t *data, const uint8_t len) {
 #define TAG_REQUEST "RQ"
 #define TAG_RESPONSE "RP"
 #define VALUE_DONTCARE "XXXX"
@@ -383,7 +383,7 @@ uint8_t requestbyten(UNUSED(uint8_t *data), char *s, uint8_t req[]) {
 
 // Parses a response's text to data.
 // Replaces special tokens with function results. This mangles resp_p->text, which shouldn't be a problem
-void sim_parse_response(struct sim_ecu_response* resp_p, uint8_t req[]) {
+void sim_parse_response(struct sim_ecu_response *resp_p, uint8_t req[]) {
 #define TOKEN_SINE1	 "sin1"
 #define TOKEN_SAWTOOTH1 "swt1"
 #define TOKEN_ISO9141CS "cks1"
@@ -538,7 +538,7 @@ sim_new(struct diag_l0_device *dl0d) {
 
 /* Clear + free the contents of dl0d; assumes L0 was closed first */
 static void
-sim_del(struct diag_l0_device * dl0d) {
+sim_del(struct diag_l0_device *dl0d) {
 	struct sim_device *dev;
 
 	assert(dl0d !=NULL);
@@ -673,7 +673,7 @@ static int
 sim_send(struct diag_l0_device *dl0d,
 		UNUSED(const char *subinterface),
 		 const void *data, const size_t len) {
-	struct sim_device * dev = dl0d->l0_int;
+	struct sim_device *dev = dl0d->l0_int;
 
 	if (len <= 0)
 		return diag_iseterr(DIAG_ERR_BADLEN);
@@ -718,8 +718,8 @@ sim_recv(struct diag_l0_device *dl0d,
 		UNUSED(const char *subinterface),
 		void *data, size_t len, unsigned int timeout) {
 	size_t xferd;
-	struct sim_ecu_response* resp_p = NULL;
-	struct sim_device * dev = dl0d->l0_int;
+	struct sim_ecu_response *resp_p = NULL;
+	struct sim_device *dev = dl0d->l0_int;
 
 	if (!len)
 		return diag_iseterr(DIAG_ERR_BADLEN);
@@ -763,7 +763,7 @@ sim_recv(struct diag_l0_device *dl0d,
 // P4 timing, and implements all types of init.
 static uint32_t
 sim_getflags(struct diag_l0_device *dl0d) {
-	struct sim_device * dev = dl0d->l0_int;
+	struct sim_device *dev = dl0d->l0_int;
 	int ret;
 
 	ret = DIAG_L1_SLOW |
@@ -790,8 +790,8 @@ sim_getflags(struct diag_l0_device *dl0d) {
 }
 
 
-static struct cfgi*
-sim_getcfg(struct diag_l0_device *dl0d) {
+static struct cfgi
+*sim_getcfg(struct diag_l0_device *dl0d) {
 	struct sim_device *dev;
 	if (dl0d==NULL) return diag_pseterr(DIAG_ERR_BADCFG);
 

--- a/scantool/diag_l1.c
+++ b/scantool/diag_l1.c
@@ -55,8 +55,7 @@ static int diag_l1_initdone=0;
 
 //diag_l1_init : parse through l0dev_list and call each ->init()
 int
-diag_l1_init(void)
-{
+diag_l1_init(void) {
 	if (diag_l1_initdone)
 		return 0;
 
@@ -94,8 +93,7 @@ int diag_l1_end(void) {
  *
  */
 int
-diag_l1_open(struct diag_l0_device *dl0d, int l1protocol)
-{
+diag_l1_open(struct diag_l0_device *dl0d, int l1protocol) {
 	if (diag_l1_debug & DIAG_DEBUG_OPEN)
 		fprintf(stderr, FLFMT "diag_l1_open(0x%p, l1 proto=%d\n", FL,
 				(void *)dl0d, l1protocol);
@@ -111,8 +109,7 @@ diag_l1_open(struct diag_l0_device *dl0d, int l1protocol)
 //diag_l1_close : call the ->close member of the
 //specified diag_l0_device.
 void
-diag_l1_close(struct diag_l0_device *dl0d)
-{
+diag_l1_close(struct diag_l0_device *dl0d) {
 	if (diag_l1_debug & DIAG_DEBUG_CLOSE)
 		fprintf(stderr, FLFMT "entering diag_l1_close: dl0d=%p\n", FL,
 			(void *) dl0d);
@@ -141,8 +138,7 @@ int diag_l1_ioctl(struct diag_l0_device *dl0d, unsigned cmd, void *data) {
  * Returns 0 on success
  */
 int
-diag_l1_send(struct diag_l0_device *dl0d, const char *subinterface, const void *data, size_t len, unsigned int p4)
-{
+diag_l1_send(struct diag_l0_device *dl0d, const char *subinterface, const void *data, size_t len, unsigned int p4) {
 	int rv = DIAG_ERR_GENERAL;
 	uint32_t l0flags;
 	uint8_t duplexbuf[MAXRBUF];
@@ -244,8 +240,7 @@ diag_l1_send(struct diag_l0_device *dl0d, const char *subinterface, const void *
  */
 int
 diag_l1_recv(struct diag_l0_device *dl0d,
-	const char *subinterface, void *data, size_t len, unsigned int timeout)
-{
+	const char *subinterface, void *data, size_t len, unsigned int timeout) {
 	int rv;
 	if (!len)
 		return diag_iseterr(DIAG_ERR_BADLEN);
@@ -276,15 +271,13 @@ diag_l1_recv(struct diag_l0_device *dl0d,
 
 
 //diag_l1_getflags: returns l0 flags
-uint32_t diag_l1_getflags(struct diag_l0_device *dl0d)
-{
+uint32_t diag_l1_getflags(struct diag_l0_device *dl0d) {
 	return diag_l0_getflags(dl0d);
 }
 
 //diag_l1_gettype: returns l1proto_mask :supported L1 protos
 //of the l0 driver
-int diag_l1_gettype(struct diag_l0_device *dl0d)
-{
+int diag_l1_gettype(struct diag_l0_device *dl0d) {
 	return dl0d->dl0->l1proto_mask;
 }
 

--- a/scantool/diag_l1.h
+++ b/scantool/diag_l1.h
@@ -169,8 +169,7 @@ extern "C" {
  */
 
 /* Argument for DIAG_IOCTL_INITBUS */
-struct diag_l1_initbus_args
-{
+struct diag_l1_initbus_args {
 	uint8_t	type;	/* Init type */
 	uint8_t	addr;	/* ECU (target) address, if iso9141 or 14230 init */
 	uint8_t	testerid;	/* tester address, for 14230 init */

--- a/scantool/diag_l2.c
+++ b/scantool/diag_l2.c
@@ -63,8 +63,7 @@ static struct l2_internal_t l2internal = {0};
  * @return NULL if not found
  */
 static struct diag_l2_link *
-diag_l2_findlink(struct diag_l0_device *dl0d)
-{
+diag_l2_findlink(struct diag_l0_device *dl0d) {
 	struct diag_l2_link *dl2l=NULL;
 
 	LL_FOREACH(l2internal.dl2l_list, dl2l) {
@@ -81,8 +80,7 @@ diag_l2_findlink(struct diag_l0_device *dl0d)
  * Always returns 0
  */
 
-static int diag_l2_rmconn(struct diag_l2_conn *dl2c)
-{
+static int diag_l2_rmconn(struct diag_l2_conn *dl2c) {
 	assert(dl2c !=NULL);
 
 	diag_os_lock(l2internal.connlist_mtx);
@@ -105,8 +103,7 @@ static int diag_l2_rmconn(struct diag_l2_conn *dl2c)
  * In order for this to work well, all L2
  */
 void
-diag_l2_timer(void)
-{
+diag_l2_timer(void) {
 	struct diag_l2_conn	*d_l2_conn;
 
 	unsigned long now;
@@ -147,8 +144,7 @@ diag_l2_timer(void)
  * (if msg was a chain of messages, they all get added so they don't get lost)
  */
 void
-diag_l2_addmsg(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+diag_l2_addmsg(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	LL_CONCAT(d_l2_conn->diag_msg, msg);
 	return;
 }
@@ -160,8 +156,7 @@ diag_l2_addmsg(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 /*
  * Init called to initialise local structures
  */
-int diag_l2_init()
-{
+int diag_l2_init() {
 
 	if (l2internal.init_done)
 		return 0;
@@ -193,8 +188,7 @@ int diag_l2_end() {
  * is not used anymore...
  */
 static int
-diag_l2_closelink(struct diag_l2_link *dl2l)
-{
+diag_l2_closelink(struct diag_l2_link *dl2l) {
 	assert(dl2l != NULL);
 
 
@@ -225,8 +219,7 @@ diag_l2_closelink(struct diag_l2_link *dl2l)
  * to know later (and asks L1)
  */
 int
-diag_l2_open(struct diag_l0_device *dl0d, int L1protocol)
-{
+diag_l2_open(struct diag_l0_device *dl0d, int L1protocol) {
 	int rv;
 	struct diag_l2_link *dl2l;
 
@@ -333,8 +326,7 @@ diag_l2_close(struct diag_l0_device *dl0d) {
  */
 struct diag_l2_conn *
 diag_l2_StartCommunications(struct diag_l0_device *dl0d, int L2protocol, flag_type flags,
-	unsigned int bitrate, target_type target, source_type source)
-{
+	unsigned int bitrate, target_type target, source_type source) {
 	struct diag_l2_conn	*d_l2_conn;
 	const struct diag_l2_proto *dl2p;
 
@@ -467,8 +459,7 @@ diag_l2_StartCommunications(struct diag_l0_device *dl0d, int L2protocol, flag_ty
  * and removes it from l2internal.dl2conn_list
  */
 int
-diag_l2_StopCommunications(struct diag_l2_conn *d_l2_conn)
-{
+diag_l2_StopCommunications(struct diag_l2_conn *d_l2_conn) {
 	assert(d_l2_conn != NULL);
 
 	d_l2_conn->diag_l2_state = DIAG_L2_STATE_CLOSING;
@@ -502,8 +493,7 @@ diag_l2_StopCommunications(struct diag_l2_conn *d_l2_conn)
  * and updates the timestamps
  */
 int
-diag_l2_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+diag_l2_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	int rv;
 
 	if (diag_l2_debug & DIAG_DEBUG_WRITE)
@@ -529,8 +519,7 @@ diag_l2_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
  * This is synchronous and sleeps and is meant too.
  */
 struct diag_msg *
-diag_l2_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg, int *errval)
-{
+diag_l2_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg, int *errval) {
 	struct diag_msg *rxmsg;
 
 	if (diag_l2_debug & DIAG_DEBUG_WRITE)
@@ -567,8 +556,7 @@ diag_l2_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg, int *errva
  */
 int
 diag_l2_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
-	void (*callback)(void *handle, struct diag_msg *msg), void *handle)
-{
+	void (*callback)(void *handle, struct diag_msg *msg), void *handle) {
 	int rv;
 
 	if (diag_l2_debug & DIAG_DEBUG_READ)
@@ -594,8 +582,7 @@ diag_l2_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
  * Unix ioctl()
  * ret 0 if ok
  */
-int diag_l2_ioctl(struct diag_l2_conn *d_l2_conn, unsigned int cmd, void *data)
-{
+int diag_l2_ioctl(struct diag_l2_conn *d_l2_conn, unsigned int cmd, void *data) {
 	struct diag_l0_device *dl0d;
 	int rv = 0;
 	struct diag_l2_data *d;

--- a/scantool/diag_l2.h
+++ b/scantool/diag_l2.h
@@ -44,8 +44,7 @@ extern "C" {
 //diag_l2_link : elements of the diag_l2_links linked-list.
 //An l2 link associates an existing diag_l0_device with
 //one L1 proto and L1 flags.
-struct diag_l2_link
-{
+struct diag_l2_link {
 	struct diag_l0_device * 	l2_dl0d;	/* Link we're using to talk to lower layer */
 	int	l1proto;		/* L1 protocol used; see diag_l1.h*/
 
@@ -63,8 +62,7 @@ struct diag_msg;
  * There is one of these per ECU we are talking to - we may be talking to
  * more than one ECU per L1 link
  */
-struct diag_l2_conn
-{
+struct diag_l2_conn {
 	enum {
 		DIAG_L2_STATE_CLOSED,	/* Not in use (but not free for anyones use !!) */
 		DIAG_L2_STATE_SENTCONREQ,	/* Sent connection request (waiting for response/reject) */
@@ -249,8 +247,7 @@ extern const struct diag_l2_proto *l2proto_list[];
 //this isn't used frequently but L3_vag will eventually need it,
 //and cmd_diag_probe uses it to report found ECUs.
 
-struct	diag_l2_data
-{
+struct	diag_l2_data {
 	uint8_t physaddr;	/* Physical address of ECU */
 	uint8_t kb1;		/* Keybyte 0 */
 	uint8_t kb2;		/* Keybyte 1 */

--- a/scantool/diag_l2.h
+++ b/scantool/diag_l2.h
@@ -45,7 +45,7 @@ extern "C" {
 //An l2 link associates an existing diag_l0_device with
 //one L1 proto and L1 flags.
 struct diag_l2_link {
-	struct diag_l0_device * 	l2_dl0d;	/* Link we're using to talk to lower layer */
+	struct diag_l0_device *l2_dl0d;	/* Link we're using to talk to lower layer */
 	int	l1proto;		/* L1 protocol used; see diag_l1.h*/
 
 	uint32_t	l1flags;		/* L1 flags, filled with diag_l1_getflags in diag_l2_open*/
@@ -328,7 +328,7 @@ int diag_l2_close(struct diag_l0_device *);
  *	@param source - source (tester) initialisation address
  * 	@return a new struct diag_l2_conn for representing the connection
  */
-struct diag_l2_conn * diag_l2_StartCommunications(struct diag_l0_device *, int L2protocol,
+struct diag_l2_conn *diag_l2_StartCommunications(struct diag_l0_device *, int L2protocol,
 	flag_type flags, unsigned int bitrate, target_type target, source_type source );
 
 /** Stop talking to an ECU;
@@ -403,21 +403,21 @@ struct diag_l2_proto {
 	//_StartCommunications: the l2 proto implementation of this should modify
 	//the timing parameters in diag_l2_conn if required; by default in
 	//diag_l2_startcommunications() iso14230 timings are used.
-	int (*diag_l2_proto_startcomms)(struct diag_l2_conn*,
+	int (*diag_l2_proto_startcomms)(struct diag_l2_conn *,
 		flag_type, unsigned int bitrate, target_type, source_type);
-	int (*diag_l2_proto_stopcomms)(struct diag_l2_conn*);
+	int (*diag_l2_proto_stopcomms)(struct diag_l2_conn *);
 	//diag_l2_proto_send : returns 0 if ok
-	int (*diag_l2_proto_send)(struct diag_l2_conn*, struct diag_msg*);
+	int (*diag_l2_proto_send)(struct diag_l2_conn *, struct diag_msg *);
 	//diag_l2_proto_recv: ret 0 if ok
 	int (*diag_l2_proto_recv)(struct diag_l2_conn *d_l2_conn,
 		unsigned int timeout, void (*callback)(void *handle, struct diag_msg *msg),
 		void *handle);
 	//diag_l2_proto_request : return a new diag_msg if succesful.
-	struct diag_msg * (*diag_l2_proto_request)(struct diag_l2_conn*,
-		struct diag_msg*, int*);
+	struct diag_msg *(*diag_l2_proto_request)(struct diag_l2_conn *,
+		struct diag_msg *, int *);
 	//diag_l2_proto_timeout : this is called periodically (interval
 	//defined in struct diag_l2_conn, usually to send keepalive messages.
-	void (*diag_l2_proto_timeout)(struct diag_l2_conn*);
+	void (*diag_l2_proto_timeout)(struct diag_l2_conn *);
 };
 
 #if defined(__cplusplus)

--- a/scantool/diag_l2_d2.c
+++ b/scantool/diag_l2_d2.c
@@ -51,8 +51,7 @@
 
 /* replace a byte's msb with a parity bit */
 static uint8_t
-with_parity(uint8_t c, enum diag_parity eo)
-{
+with_parity(uint8_t c, enum diag_parity eo) {
 	uint8_t p;
 	int i;
 
@@ -67,8 +66,7 @@ with_parity(uint8_t c, enum diag_parity eo)
 }
 
 static int
-dl2p_d2_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+dl2p_d2_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	int rv;
 	uint8_t buf[3 + 62 + 1];
 	struct diag_l2_d2 *dp;
@@ -95,8 +93,7 @@ dl2p_d2_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 static int
 dl2p_d2_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 	void (*callback)(void *handle, struct diag_msg *msg),
-	void *handle)
-{
+	void *handle) {
 	int rv;
 	uint8_t buf[3 + 62 + 1];
 	struct diag_msg *msg;
@@ -127,16 +124,14 @@ dl2p_d2_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 }
 
 static void
-dl2p_d2_request_callback(void *handle, struct diag_msg *in)
-{
+dl2p_d2_request_callback(void *handle, struct diag_msg *in) {
 	struct diag_msg **out = (struct diag_msg **)handle;
 	*out = diag_dupsinglemsg(in);
 }
 
 static struct diag_msg *
 dl2p_d2_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
-                int *errval)
-{
+                int *errval) {
 	int rv;
 	struct diag_msg *rmsg;
 
@@ -161,13 +156,12 @@ dl2p_d2_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
 
 static int
 dl2p_d2_startcomms(struct diag_l2_conn *d_l2_conn, flag_type flags,
-	unsigned int bitrate, target_type target, source_type source)
-{
+	unsigned int bitrate, target_type target, source_type source) {
 	struct diag_serial_settings set;
 	struct diag_l2_d2 *dp;
 	int rv;
-	struct diag_msg wm={0};
-	uint8_t wm_data[]={0x82, 0, 0, 0xa1};
+	struct diag_msg wm = {0};
+	uint8_t wm_data[] = {0x82, 0, 0, 0xa1};
 	struct diag_l1_initbus_args in;
 
 	if (!(d_l2_conn->diag_link->l1flags & DIAG_L1_DOESFULLINIT) || !(d_l2_conn->diag_link->l1flags & DIAG_L1_DOESL2CKSUM)) {
@@ -245,8 +239,7 @@ err:
 }
 
 static int
-dl2p_d2_stopcomms(struct diag_l2_conn* pX)
-{
+dl2p_d2_stopcomms(struct diag_l2_conn* pX) {
 	struct diag_msg msg = {0};
 	uint8_t data[] = { 0xa0 };
 	int errval = 0;
@@ -275,8 +268,7 @@ dl2p_d2_stopcomms(struct diag_l2_conn* pX)
 }
 
 static void
-dl2p_d2_timeout(struct diag_l2_conn *d_l2_conn)
-{
+dl2p_d2_timeout(struct diag_l2_conn *d_l2_conn) {
 	struct diag_msg msg = {0};
 	uint8_t data[] = { 0xa1 };
 	int errval = 0;

--- a/scantool/diag_l2_d2.c
+++ b/scantool/diag_l2_d2.c
@@ -239,7 +239,7 @@ err:
 }
 
 static int
-dl2p_d2_stopcomms(struct diag_l2_conn* pX) {
+dl2p_d2_stopcomms(struct diag_l2_conn *pX) {
 	struct diag_msg msg = {0};
 	uint8_t data[] = { 0xa0 };
 	int errval = 0;

--- a/scantool/diag_l2_d2.h
+++ b/scantool/diag_l2_d2.h
@@ -1,8 +1,7 @@
 #ifndef _DIAG_L2_D2_H_
 #define _DIAG_L2_D2_H_
 
-struct diag_l2_d2
-{
+struct diag_l2_d2 {
 	uint8_t srcaddr;
 	uint8_t dstaddr;
 };

--- a/scantool/diag_l2_iso14230.c
+++ b/scantool/diag_l2_iso14230.c
@@ -55,8 +55,7 @@
 static int
 dl2p_14230_decode(uint8_t *data, int len,
 		 uint8_t *hdrlen, int *datalen, uint8_t *source, uint8_t *dest,
-		int first_frame)
-{
+		int first_frame) {
 	uint8_t dl;
 
 	if (diag_l2_debug & DIAG_DEBUG_PROTO) {
@@ -68,8 +67,7 @@ dl2p_14230_decode(uint8_t *data, int len,
 	dl = data[0] & 0x3f;
 	if (dl == 0) {
 		/* Additional length field present */
-		switch (data[0] & 0xC0)
-		{
+		switch (data[0] & 0xC0) {
 		case 0x80:
 		case 0xC0:
 			/* Addresses supplied, additional len byte */
@@ -145,8 +143,7 @@ dl2p_14230_decode(uint8_t *data, int len,
 		return diag_iseterr(DIAG_ERR_BADDATA);
 
 
-	if (diag_l2_debug & DIAG_DEBUG_PROTO)
-	{
+	if (diag_l2_debug & DIAG_DEBUG_PROTO) {
 		fprintf(stderr, FLFMT "decode hdrlen=%d, datalen=%d, cksum=1\n",
 			FL, *hdrlen, *datalen);
 	}
@@ -194,8 +191,7 @@ dl2p_14230_decode(uint8_t *data, int len,
 
  */
 static int
-dl2p_14230_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
-{
+dl2p_14230_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout) {
 	struct diag_l2_14230 *dp;
 	int rv, l1_doesl2frame, l1flags;
 	unsigned int tout;
@@ -494,10 +490,9 @@ dl2p_14230_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg);
  */
 static int
 dl2p_14230_startcomms( struct diag_l2_conn	*d_l2_conn, flag_type flags,
-	unsigned int bitrate, target_type target, source_type source)
-{
+	unsigned int bitrate, target_type target, source_type source) {
 	struct diag_l2_14230 *dp;
-	struct diag_msg msg={0};
+	struct diag_msg msg = {0};
 	uint8_t data[MAXRBUF];
 	int rv;
 	unsigned int wait_time;
@@ -786,9 +781,8 @@ dl2p_14230_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
  * STATE_CLOSING so the keepalive should be disabled
  */
 static int
-dl2p_14230_stopcomms(struct diag_l2_conn* pX)
-{
-	struct diag_msg stopmsg={0};
+dl2p_14230_stopcomms(struct diag_l2_conn* pX) {
+	struct diag_msg stopmsg = {0};
 	struct diag_msg *rxmsg;
 	uint8_t stopreq=DIAG_KW2K_SI_SPR;
 	int errval=0;
@@ -841,8 +835,7 @@ dl2p_14230_stopcomms(struct diag_l2_conn* pX)
  * argument msg must have .len, .data, .dest and .src assigned.
  */
 static int
-dl2p_14230_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+dl2p_14230_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	int rv;
 	size_t len;
 	uint8_t buf[MAXRBUF];
@@ -898,7 +891,7 @@ dl2p_14230_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 
 
 
-	if ((dp->modeflags & ISO14230_FMTLEN)|| !(dp->modeflags & ISO14230_LENBYTE))  {
+	if ((dp->modeflags & ISO14230_FMTLEN)|| !(dp->modeflags & ISO14230_LENBYTE)) {
 		//if ECU supports length in format byte, or doesn't support extra len byte
 		if (msg->len < 64) {
 			buf[0] |= msg->len;
@@ -960,8 +953,7 @@ dl2p_14230_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 static int
 dl2p_14230_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 	void (*callback)(void *handle, struct diag_msg *msg),
-	void *handle)
-{
+	void *handle) {
 	int rv;
 
 	/* Call internal routine */
@@ -997,8 +989,7 @@ dl2p_14230_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 //Sends using diag_l2_send() in order to have the timestamps updated
 static struct diag_msg *
 dl2p_14230_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
-		int *errval)
-{
+		int *errval) {
 	int rv;
 	struct diag_msg *rmsg = NULL;
 	int retries=3;	//if we get a BusyRepeatRequest response.
@@ -1099,10 +1090,9 @@ dl2p_14230_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
  * soon, so send it a keepalive message now.
  */
 static void
-dl2p_14230_timeout(struct diag_l2_conn *d_l2_conn)
-{
+dl2p_14230_timeout(struct diag_l2_conn *d_l2_conn) {
 	struct diag_l2_14230 *dp;
-	struct diag_msg msg={0};
+	struct diag_msg msg = {0};
 	uint8_t data[256];
 	unsigned int timeout;
 	int debug_l2_orig=diag_l2_debug;	//save debug flags; disable them for this procedure

--- a/scantool/diag_l2_iso14230.c
+++ b/scantool/diag_l2_iso14230.c
@@ -781,12 +781,12 @@ dl2p_14230_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
  * STATE_CLOSING so the keepalive should be disabled
  */
 static int
-dl2p_14230_stopcomms(struct diag_l2_conn* pX) {
+dl2p_14230_stopcomms(struct diag_l2_conn *pX) {
 	struct diag_msg stopmsg = {0};
 	struct diag_msg *rxmsg;
 	uint8_t stopreq=DIAG_KW2K_SI_SPR;
 	int errval=0;
-	char * debugstr;
+	char *debugstr;
 
 	stopmsg.len=1;
 	stopmsg.data=&stopreq;

--- a/scantool/diag_l2_iso14230.h
+++ b/scantool/diag_l2_iso14230.h
@@ -34,8 +34,7 @@
 /*
  * ISO 14230 specific data
  */
-struct diag_l2_14230
-{
+struct diag_l2_14230 {
 	uint8_t initype;		/* init type : FAST/SLOW/CARB */
 
 	uint8_t srcaddr;	/* Src address used */

--- a/scantool/diag_l2_iso9141.c
+++ b/scantool/diag_l2_iso9141.c
@@ -246,7 +246,7 @@ dl2p_iso9141_startcomms(struct diag_l2_conn *d_l2_conn,
  * so we just "undo" what iso9141_startcomms did.
  */
 static int
-dl2p_iso9141_stopcomms(struct diag_l2_conn* d_l2_conn) {
+dl2p_iso9141_stopcomms(struct diag_l2_conn *d_l2_conn) {
 	struct diag_l2_iso9141 *dp;
 
 	dp = (struct diag_l2_iso9141 *)d_l2_conn->diag_l2_proto_data;

--- a/scantool/diag_l2_iso9141.c
+++ b/scantool/diag_l2_iso9141.c
@@ -61,8 +61,7 @@
  * This concludes a successfull handshaking in ISO9141.
  */
 int
-dl2p_iso9141_wakeupECU(struct diag_l2_conn *d_l2_conn)
-{
+dl2p_iso9141_wakeupECU(struct diag_l2_conn *d_l2_conn) {
 	struct diag_l1_initbus_args in;
 	uint8_t kb1, kb2, address, inv_address, inv_kb2;
 	int rv = 0;
@@ -124,8 +123,7 @@ dl2p_iso9141_wakeupECU(struct diag_l2_conn *d_l2_conn)
 	// Now send inverted KeyByte2, and receive inverted address
 	// (unless L1 deals with this):
 	if ( (d_l2_conn->diag_link->l1flags
-	  & DIAG_L1_DOESSLOWINIT) == 0)
-	{
+	  & DIAG_L1_DOESSLOWINIT) == 0) {
 		//Wait W4min:
 		diag_os_millisleep(W4min);
 
@@ -142,8 +140,7 @@ dl2p_iso9141_wakeupECU(struct diag_l2_conn *d_l2_conn)
 		//NOTE : l2_iso14230 uses a huge 350ms timeout for this!!
 		rv = diag_l1_recv (d_l2_conn->diag_link->l2_dl0d, 0,
 					&inv_address, 1, W4max + RXTOFFSET);
-		if (rv < 0)
-		{
+		if (rv < 0) {
 			if (diag_l2_debug & DIAG_DEBUG_OPEN)
 				fprintf(stderr,
 					FLFMT "wakeupECU(dl2conn %p) did not get inv. address; rx error %d\n",
@@ -152,8 +149,7 @@ dl2p_iso9141_wakeupECU(struct diag_l2_conn *d_l2_conn)
 		}
 
 		// Check the received inverted address:
-		if ( inv_address != ((~address) & 0xff))
-		{
+		if ( inv_address != ((~address) & 0xff)) {
 			fprintf(stderr,
 					FLFMT "wakeupECU(dl2conn %p) addr mismatch: 0x%02X != 0x%02X\n",
 					FL, (void *)d_l2_conn, inv_address, ~address);
@@ -179,8 +175,7 @@ dl2p_iso9141_wakeupECU(struct diag_l2_conn *d_l2_conn)
 static int
 dl2p_iso9141_startcomms(struct diag_l2_conn *d_l2_conn,
 				 flag_type flags, unsigned int bitrate,
-				 target_type target, source_type source)
-{
+				 target_type target, source_type source) {
 	int rv;
 	struct diag_serial_settings set;
 	struct diag_l2_iso9141 *dp;
@@ -251,8 +246,7 @@ dl2p_iso9141_startcomms(struct diag_l2_conn *d_l2_conn,
  * so we just "undo" what iso9141_startcomms did.
  */
 static int
-dl2p_iso9141_stopcomms(struct diag_l2_conn* d_l2_conn)
-{
+dl2p_iso9141_stopcomms(struct diag_l2_conn* d_l2_conn) {
 	struct diag_l2_iso9141 *dp;
 
 	dp = (struct diag_l2_iso9141 *)d_l2_conn->diag_l2_proto_data;
@@ -277,8 +271,7 @@ dl2p_iso9141_stopcomms(struct diag_l2_conn* d_l2_conn)
  */
 static int
 dl2p_iso9141_decode(uint8_t *data, int len,
-				 uint8_t *hdrlen, int *datalen, uint8_t *source, uint8_t *dest)
-{
+				 uint8_t *hdrlen, int *datalen, uint8_t *source, uint8_t *dest) {
 
 	if (diag_l2_debug & DIAG_DEBUG_PROTO) {
 		fprintf(stderr, FLFMT "decode len %d: ", FL, len);
@@ -334,8 +327,7 @@ dl2p_iso9141_decode(uint8_t *data, int len,
  * Do we let L3_saej1979 try and DJ the framing through L2 ?
  */
 int
-dl2p_iso9141_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
-{
+dl2p_iso9141_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout) {
 	int rv, l1_doesl2frame, l1flags;
 	unsigned int tout = 0;
 	int state;
@@ -354,8 +346,7 @@ dl2p_iso9141_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
 	dp = (struct diag_l2_iso9141 *)d_l2_conn->diag_l2_proto_data;
 
 	// Clear out last received message if not done already.
-	if (d_l2_conn->diag_msg)
-	{
+	if (d_l2_conn->diag_msg) {
 		diag_freemsg(d_l2_conn->diag_msg);
 		d_l2_conn->diag_msg = NULL;
 	}
@@ -377,10 +368,8 @@ dl2p_iso9141_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
 	// We are a bit more flexible than that, see below.
 	// Frames get acumulated in the protocol structure list.
 	state = ST_STATE1;
-	while (1)
-	{
-		switch(state)
-		{
+	while (1) {
+		switch(state) {
 			case ST_STATE1:
 				// Ready for first byte, use timeout
 				// specified by user.
@@ -447,8 +436,7 @@ dl2p_iso9141_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
 						(size_t)dp->rxoffset);
 					tmsg->rxtime = diag_os_getms();
 
-					if (diag_l2_debug & DIAG_DEBUG_READ)
-					{
+					if (diag_l2_debug & DIAG_DEBUG_READ) {
 						fprintf(stderr, "l2_iso9141_recv: ");
 						diag_data_dump(stderr, dp->rxbuf, (size_t)dp->rxoffset);
 						fprintf(stderr, "\n");
@@ -602,13 +590,11 @@ dl2p_iso9141_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
 //ret 0 if ok
 static int
 dl2p_iso9141_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
-			void (*callback)(void *handle, struct diag_msg *msg), void *handle)
-{
+			void (*callback)(void *handle, struct diag_msg *msg), void *handle) {
 	int rv;
 
 	rv = dl2p_iso9141_int_recv(d_l2_conn, timeout);
-	if ((rv >= 0) && (d_l2_conn->diag_msg !=NULL))
-	{
+	if ((rv >= 0) && (d_l2_conn->diag_msg !=NULL)) {
 		if (diag_l2_debug & DIAG_DEBUG_READ)
 			fprintf(stderr, FLFMT "_recv : handle=%p\n", FL,
 				(void *)handle);	//%pcallback! we won't try to printf the callback pointer.
@@ -634,8 +620,7 @@ dl2p_iso9141_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
  * ret 0 if ok
  */
 static int
-dl2p_iso9141_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+dl2p_iso9141_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	int rv;
 	unsigned int sleeptime;
 	uint8_t buf[MAXLEN_ISO9141];
@@ -650,8 +635,7 @@ dl2p_iso9141_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 		FL, (void *)d_l2_conn, (void *)msg);
 
 	// Check if the payload plus the overhead (and checksum) exceed protocol packet size:
-	if(msg->len + OHLEN_ISO9141 > MAXLEN_ISO9141)
-	{
+	if(msg->len + OHLEN_ISO9141 > MAXLEN_ISO9141) {
 		fprintf(stderr, FLFMT "send: Message payload exceeds maximum allowed by protocol!\n", FL);
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
@@ -685,14 +669,12 @@ dl2p_iso9141_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 	offset += msg->len;
 
 	// If the interface doesn't do ISO9141-2 checksum, add it in:
-	if ((d_l2_conn->diag_link->l1flags & DIAG_L1_DOESL2CKSUM) == 0)
-	{
+	if ((d_l2_conn->diag_link->l1flags & DIAG_L1_DOESL2CKSUM) == 0) {
 		uint8_t curoff = (uint8_t) offset;
 		buf[offset++] = diag_cks1(buf, curoff);
 	}
 
-	if (diag_l2_debug & DIAG_DEBUG_WRITE)
-	{
+	if (diag_l2_debug & DIAG_DEBUG_WRITE) {
 		fprintf(stderr, "l2_iso9141_send: ");
 		diag_data_dump(stderr, buf, (size_t)offset);
 		fprintf(stderr, "\n");
@@ -710,28 +692,24 @@ dl2p_iso9141_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 //_request: ret a new message if ok; NULL if failed
 static struct diag_msg *
 dl2p_iso9141_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
-				  int *errval)
-{
+				  int *errval) {
 	int rv;
 	struct diag_msg *rmsg = NULL;
 
 	rv = diag_l2_send(d_l2_conn, msg);
-	if (rv < 0)
-	{
+	if (rv < 0) {
 		*errval = rv;
 		return NULL;
 	}
 
 	/* And wait for response */
 	rv = dl2p_iso9141_int_recv(d_l2_conn, d_l2_conn->diag_l2_p2max + RXTOFFSET);
-	if ((rv >= 0) && d_l2_conn->diag_msg)
-	{
+	if ((rv >= 0) && d_l2_conn->diag_msg) {
 		/* OK */
 		rmsg = d_l2_conn->diag_msg;
 		d_l2_conn->diag_msg = NULL;
 	}
-	else
-	{
+	else {
 		/* Error */
 		*errval = DIAG_ERR_TIMEOUT;
 		rmsg = NULL;
@@ -740,8 +718,7 @@ dl2p_iso9141_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
 	return rmsg;
 }
 
-const struct diag_l2_proto diag_l2_proto_iso9141 =
-{
+const struct diag_l2_proto diag_l2_proto_iso9141 = {
 	DIAG_L2_PROT_ISO9141,
 	"ISO9141",
 	DIAG_L2_FLAG_FRAMED,

--- a/scantool/diag_l2_iso9141.c
+++ b/scantool/diag_l2_iso9141.c
@@ -708,8 +708,7 @@ dl2p_iso9141_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
 		/* OK */
 		rmsg = d_l2_conn->diag_msg;
 		d_l2_conn->diag_msg = NULL;
-	}
-	else {
+	} else {
 		/* Error */
 		*errval = DIAG_ERR_TIMEOUT;
 		rmsg = NULL;

--- a/scantool/diag_l2_iso9141.h
+++ b/scantool/diag_l2_iso9141.h
@@ -62,8 +62,7 @@ extern "C" {
 /*
  * ISO9141 specific data
  */
-struct diag_l2_iso9141
-{
+struct diag_l2_iso9141 {
 	uint8_t srcaddr;	// Src address used, normally 0xF1 (tester)
 	uint8_t target;	// Target address used, normally 0x33 (ISO9141)
 

--- a/scantool/diag_l2_mb1.c
+++ b/scantool/diag_l2_mb1.c
@@ -50,8 +50,7 @@ dl2p_mb1_startcomms( struct diag_l2_conn *d_l2_conn,
 UNUSED(flag_type flags),
 unsigned int bitrate,
 target_type target,
-UNUSED(source_type source))
-{
+UNUSED(source_type source)) {
 	struct diag_l1_initbus_args in;
 	uint8_t cbuf[2];
 	int rv;
@@ -105,8 +104,7 @@ UNUSED(source_type source))
 		return diag_iseterr(rv);
 	rv = diag_l1_recv (d_l2_conn->diag_link->l2_dl0d, 0,
 		&cbuf[1], 1, 100);
-	if (rv < 0)
-	{
+	if (rv < 0) {
 		return diag_iseterr(rv);
 	}
 
@@ -153,13 +151,11 @@ dl2p_mb1_stopcomms(UNUSED(struct diag_l2_conn* dl2c)) {
  * Data/len is received data/len
  */
 static int
-dl2p_mb1_decode(uint8_t *data, int len, int *msglen)
-{
+dl2p_mb1_decode(uint8_t *data, int len, int *msglen) {
 	uint16_t cksum;
 	int i;
 
-	if (diag_l2_debug & DIAG_DEBUG_READ)
-	{
+	if (diag_l2_debug & DIAG_DEBUG_READ) {
 		fprintf(stderr, FLFMT "decode len %d", FL, len);
 		for (i = 0; i < len ; i++)
 			fprintf(stderr, " 0x%X", data[i]&0xff);
@@ -177,16 +173,14 @@ dl2p_mb1_decode(uint8_t *data, int len, int *msglen)
 
 	for (i=0, cksum=0; i < len-2; i++)
 		cksum += data[i];
-	if (data[len-2] != (cksum &0xff))
-	{
+	if (data[len-2] != (cksum &0xff)) {
 		if (diag_l2_debug & DIAG_DEBUG_READ)
 			fprintf(stderr, FLFMT "recv cksum 0x%02X 0x%02X, wanted 0x%X\n",
 				FL, data[len-1] & 0xff,
 				data[len-2] &0xff, cksum & 0xffff);
 		return diag_iseterr(DIAG_ERR_BADCSUM);
 	}
-	if (data[len-1] != ((cksum>>8) & 0xff))
-	{
+	if (data[len-1] != ((cksum>>8) & 0xff)) {
 		if (diag_l2_debug & DIAG_DEBUG_READ)
 			fprintf(stderr, FLFMT "recv cksum 0x%02X 0x%02X, wanted 0x%X\n",
 				FL, data[len-1] & 0xff,
@@ -202,8 +196,7 @@ dl2p_mb1_decode(uint8_t *data, int len, int *msglen)
  */
 static int
 dl2p_mb1_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
-	uint8_t *data, int len)
-{
+	uint8_t *data, int len) {
 	int rxoffset, rv;
 	unsigned int tout;
 	int msglen;
@@ -214,8 +207,7 @@ dl2p_mb1_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 	msglen = 0;
 	readlen = 3;
 	while ( (rv = diag_l1_recv (d_l2_conn->diag_link->l2_dl0d, 0,
-			&data[rxoffset], readlen, tout)) > 0)
-	{
+			&data[rxoffset], readlen, tout)) > 0) {
 		rxoffset += rv;
 		tout = 100;
 
@@ -223,13 +215,11 @@ dl2p_mb1_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 
 		rv = dl2p_mb1_decode(data, rxoffset, &msglen);
 
-		if (rv >= 0)
-		{
+		if (rv >= 0) {
 			/* Full packet ! */
 			break;
 		}
-		else if (rv != DIAG_ERR_INCDATA)
-		{
+		else if (rv != DIAG_ERR_INCDATA) {
 			/* Bad things happened */
 			rxoffset = rv;
 			break;
@@ -254,8 +244,7 @@ dl2p_mb1_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
  */
 static int
 dl2p_mb1_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
-	void (*callback)(void *handle, struct diag_msg *msg), void *handle)
-{
+	void (*callback)(void *handle, struct diag_msg *msg), void *handle) {
 	uint8_t	rxbuf[MAXRBUF];
 	int rv;
 	struct diag_msg *msg;
@@ -270,8 +259,7 @@ dl2p_mb1_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 		fprintf(stderr,
 			FLFMT "recv conn %p got %d byte message\n",
 				FL, (void *)d_l2_conn, rv);	//%pcallback! we won't try to printf the callback pointer.
-	if (rv < 5)
-	{
+	if (rv < 5) {
 		/* Bad, minimum message is 5 bytes */
 		return diag_iseterr(DIAG_ERR_BADDATA);
 	}
@@ -307,8 +295,7 @@ dl2p_mb1_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
  * ret 0 if ok
  */
 static int
-dl2p_mb1_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+dl2p_mb1_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	int rv;
 	unsigned int sleeptime;
 	uint8_t txbuf[MAXRBUF];
@@ -343,8 +330,7 @@ dl2p_mb1_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 	txbuf[msg->len+3] = (uint8_t) ((cksum>>8) & 0xff);
 
 	if ( (diag_l2_debug & DIAG_DEBUG_WRITE) &&
-			(diag_l2_debug & DIAG_DEBUG_DATA))
-	{
+			(diag_l2_debug & DIAG_DEBUG_DATA)) {
 		fprintf(stderr, FLFMT "About to send %d bytes: ", FL, txbuf[2]);
 		for (i=0; i<txbuf[2]; i++)
 			fprintf(stderr, "0x%02X ", txbuf[i]);
@@ -360,15 +346,13 @@ dl2p_mb1_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 
 static struct diag_msg *
 dl2p_mb1_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
-		int *errval)
-{
+		int *errval) {
 	int rv;
 	struct diag_msg *rmsg = NULL;
 	uint8_t	rxbuf[MAXRBUF];
 
 	rv = diag_l2_send(d_l2_conn, msg);
-	if (rv < 0)
-	{
+	if (rv < 0) {
 		*errval = rv;
 		return diag_pseterr(DIAG_ERR_GENERAL);
 	}
@@ -381,16 +365,14 @@ dl2p_mb1_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
 		fprintf(stderr,
 			FLFMT "msg receive conn %p got %d byte message\n",
 				FL, (void *)d_l2_conn, rv);
-	if (rv < 5 || rv > (255+4))
-	{
+	if (rv < 5 || rv > (255+4)) {
 		/* Bad, minimum message is 5 bytes, or error happened */
 		if (rv < 0)
 			*errval = rv;
 		else
 			*errval = DIAG_ERR_BADDATA;
 	}
-	else
-	{
+	else {
 		/*
 		 * Ok, alloc a message
 		 */
@@ -410,9 +392,8 @@ dl2p_mb1_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
  * Timeout, called to send idle packet to keep link to ECU alive
  */
 static void
-dl2p_mb1_timeout(struct diag_l2_conn *d_l2_conn)
-{
-	struct diag_msg msg={0};
+dl2p_mb1_timeout(struct diag_l2_conn *d_l2_conn) {
+	struct diag_msg msg = {0};
 	uint8_t txbuf[8];
 	uint8_t rxbuf[1000];
 	int rv;

--- a/scantool/diag_l2_mb1.c
+++ b/scantool/diag_l2_mb1.c
@@ -138,7 +138,7 @@ UNUSED(source_type source)) {
 }
 
 static int
-dl2p_mb1_stopcomms(UNUSED(struct diag_l2_conn* dl2c)) {
+dl2p_mb1_stopcomms(UNUSED(struct diag_l2_conn *dl2c)) {
 	return 0;
 }
 

--- a/scantool/diag_l2_mb1.c
+++ b/scantool/diag_l2_mb1.c
@@ -218,8 +218,7 @@ dl2p_mb1_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 		if (rv >= 0) {
 			/* Full packet ! */
 			break;
-		}
-		else if (rv != DIAG_ERR_INCDATA) {
+		} else if (rv != DIAG_ERR_INCDATA) {
 			/* Bad things happened */
 			rxoffset = rv;
 			break;
@@ -371,8 +370,7 @@ dl2p_mb1_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
 			*errval = rv;
 		else
 			*errval = DIAG_ERR_BADDATA;
-	}
-	else {
+	} else {
 		/*
 		 * Ok, alloc a message
 		 */

--- a/scantool/diag_l2_raw.c
+++ b/scantool/diag_l2_raw.c
@@ -47,8 +47,7 @@ dl2p_raw_startcomms( struct diag_l2_conn *d_l2_conn,
 UNUSED(flag_type flags),
 unsigned int bitrate,
 target_type target,
-source_type source)
-{
+source_type source) {
 	int rv;
 	struct diag_serial_settings set;
 
@@ -74,8 +73,7 @@ source_type source)
 */
 
 int
-dl2p_raw_stopcomms(UNUSED(struct diag_l2_conn* pX))
-{
+dl2p_raw_stopcomms(UNUSED(struct diag_l2_conn* pX)) {
 	return 0;
 }
 
@@ -84,8 +82,7 @@ dl2p_raw_stopcomms(UNUSED(struct diag_l2_conn* pX))
  * ret 0 if ok
  */
 int
-dl2p_raw_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+dl2p_raw_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	int rv;
 
 	if (diag_l2_debug & DIAG_DEBUG_WRITE)
@@ -103,10 +100,9 @@ dl2p_raw_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 */
 int
 dl2p_raw_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
-	void (*callback)(void *handle, struct diag_msg *msg), void *handle)
-{
+	void (*callback)(void *handle, struct diag_msg *msg), void *handle) {
 	uint8_t rxbuf[MAXRBUF];
-	struct diag_msg msg={0};	//local message structure that will disappear when we return
+	struct diag_msg msg = {0};	//local message structure that will disappear when we return
 	int rv;
 
 	/*
@@ -125,8 +121,7 @@ dl2p_raw_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 	msg.idata=NULL;
 	msg.rxtime = diag_os_getms();
 
-	if (diag_l2_debug & DIAG_DEBUG_READ)
-	{
+	if (diag_l2_debug & DIAG_DEBUG_READ) {
 		fprintf(stderr, FLFMT "l2_proto_raw_recv: handle=%p\n", FL,
 			(void *)handle);	//%pcallback! we won't try to printf the callback pointer.
 	}
@@ -145,8 +140,7 @@ dl2p_raw_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 */
 struct diag_msg *
 dl2p_raw_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
-		int *errval)
-{
+		int *errval) {
 	int rv;
 	struct diag_msg *rmsg = NULL;
 	uint8_t rxbuf[MAXRBUF];

--- a/scantool/diag_l2_raw.c
+++ b/scantool/diag_l2_raw.c
@@ -73,7 +73,7 @@ source_type source) {
 */
 
 int
-dl2p_raw_stopcomms(UNUSED(struct diag_l2_conn* pX)) {
+dl2p_raw_stopcomms(UNUSED(struct diag_l2_conn *pX)) {
 	return 0;
 }
 

--- a/scantool/diag_l2_raw.h
+++ b/scantool/diag_l2_raw.h
@@ -43,7 +43,7 @@ dl2p_raw_startcomms( struct diag_l2_conn *d_l2_conn, flag_type flags,
 /*
 */
 int
-dl2p_raw_stopcomms(struct diag_l2_conn* pX);
+dl2p_raw_stopcomms(struct diag_l2_conn *pX);
 
 /*
  * Just send the data, with no processing etc

--- a/scantool/diag_l2_saej1850.c
+++ b/scantool/diag_l2_saej1850.c
@@ -106,7 +106,7 @@ target_type target, source_type source) {
 /*
 */
 static int
-dl2p_j1850_stopcomms(struct diag_l2_conn* d_l2_conn) {
+dl2p_j1850_stopcomms(struct diag_l2_conn *d_l2_conn) {
 	struct diag_l2_j1850 *dp;
 
 	dp = (struct diag_l2_j1850 *)d_l2_conn->diag_l2_proto_data;

--- a/scantool/diag_l2_saej1850.c
+++ b/scantool/diag_l2_saej1850.c
@@ -135,8 +135,7 @@ dl2p_j1850_crc(uint8_t *msg_buf, int nbytes) {
 				else
 					poly=0x1c;
 				crc_reg= ( (crc_reg << 1) | 1) ^ poly;
-			}
-			else {		// case for new bit = 0
+			} else {		// case for new bit = 0
 				poly=0;
 				if (crc_reg & 0x80)
 					poly=0x1d;

--- a/scantool/diag_l2_saej1850.c
+++ b/scantool/diag_l2_saej1850.c
@@ -46,8 +46,7 @@
 /*
  * SAEJ1850 specific data
  */
-struct diag_l2_j1850
-{
+struct diag_l2_j1850 {
 	uint8_t type;		/* FAST/SLOW/CARB */
 
 	uint8_t srcaddr;	/* Src address used */
@@ -76,8 +75,7 @@ static int
 dl2p_j1850_startcomms(struct diag_l2_conn	*d_l2_conn,
 UNUSED(flag_type flags),
 UNUSED(unsigned int bitrate),
-target_type target, source_type source)
-{
+target_type target, source_type source) {
 	struct diag_l2_j1850 *dp;
 
 	if (diag_l2_debug & DIAG_DEBUG_OPEN)
@@ -108,8 +106,7 @@ target_type target, source_type source)
 /*
 */
 static int
-dl2p_j1850_stopcomms(struct diag_l2_conn* d_l2_conn)
-{
+dl2p_j1850_stopcomms(struct diag_l2_conn* d_l2_conn) {
 	struct diag_l2_j1850 *dp;
 
 	dp = (struct diag_l2_j1850 *)d_l2_conn->diag_l2_proto_data;
@@ -125,26 +122,21 @@ dl2p_j1850_stopcomms(struct diag_l2_conn* d_l2_conn)
 
 /* Thanks to B. Roadman's web site for this CRC code */
 uint8_t
-dl2p_j1850_crc(uint8_t *msg_buf, int nbytes)
-{
+dl2p_j1850_crc(uint8_t *msg_buf, int nbytes) {
 	uint8_t crc_reg=0xff,poly,i,j;
 	uint8_t *byte_point;
 	uint8_t bit_point;
 
-	for (i=0, byte_point=msg_buf; i<nbytes; ++i, ++byte_point)
-	{
-		for (j=0, bit_point=0x80 ; j<8; ++j, bit_point>>=1)
-		{
-			if (bit_point & *byte_point)	// case for new bit = 1
-			{
+	for (i=0, byte_point=msg_buf; i<nbytes; ++i, ++byte_point) {
+		for (j=0, bit_point=0x80 ; j<8; ++j, bit_point>>=1) {
+			if (bit_point & *byte_point) {	// case for new bit = 1
 				if (crc_reg & 0x80)
 					poly=1;	// define the polynomial
 				else
 					poly=0x1c;
 				crc_reg= ( (crc_reg << 1) | 1) ^ poly;
 			}
-			else		// case for new bit = 0
-			{
+			else {		// case for new bit = 0
 				poly=0;
 				if (crc_reg & 0x80)
 					poly=0x1d;
@@ -162,8 +154,7 @@ dl2p_j1850_crc(uint8_t *msg_buf, int nbytes)
  * ret 0 if ok
  */
 static int
-dl2p_j1850_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+dl2p_j1850_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	int l1flags, rv, l1protocol;
 	struct diag_l2_j1850 *dp;
 
@@ -231,8 +222,7 @@ dl2p_j1850_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
  * Ret 0 if ok, whether or not there were any messages.
  */
 static int
-dl2p_j1850_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
-{
+dl2p_j1850_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout) {
 	int rv;
 	struct diag_l2_j1850 *dp;
 	unsigned long long t_done;	//time elapsed
@@ -351,8 +341,7 @@ dl2p_j1850_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
 static int
 dl2p_j1850_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 	void (*callback)(void *handle, struct diag_msg *msg),
-	void *handle)
-{
+	void *handle) {
 	int rv;
 	struct diag_msg	*tmsg;
 
@@ -370,8 +359,7 @@ dl2p_j1850_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 	/*
 	 * We now have data stored on the L2 descriptor
 	 */
-	if (diag_l2_debug & DIAG_DEBUG_READ)
-	{
+	if (diag_l2_debug & DIAG_DEBUG_READ) {
 		fprintf(stderr, FLFMT "calling rcv msg=%p callback, handle=%p\n",
 			FL, (void *)d_l2_conn->diag_msg, (void *)handle);	//%pcallback! we won't try to printf the callback pointer.
 	}
@@ -397,8 +385,7 @@ dl2p_j1850_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
  */
 static struct diag_msg *
 dl2p_j1850_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
-		int *errval)
-{
+		int *errval) {
 	int rv;
 	struct diag_msg *rmsg = NULL;
 

--- a/scantool/diag_l2_vag.c
+++ b/scantool/diag_l2_vag.c
@@ -60,8 +60,7 @@
 /*
  * ISO vag specific data
  */
-struct diag_l2_vag
-{
+struct diag_l2_vag {
 	uint8_t seq_nr; //Sequence number
 	uint8_t master; //Master flag, 1 = us, 0 = ECU
 	uint8_t first_telegram_started;
@@ -85,8 +84,7 @@ struct diag_l2_vag
  * Returns 0 on success, errorcode<0 on errors
  */
 static struct diag_msg *
-diag_l2_vag_block_recv(struct diag_l2_conn *d_l2_conn, int *errval, int msg_timeout)
-{
+diag_l2_vag_block_recv(struct diag_l2_conn *d_l2_conn, int *errval, int msg_timeout) {
 	int rv;
 	struct diag_l2_vag *dp = (struct diag_l2_vag *)d_l2_conn->diag_l2_proto_data;
 	//prepare a No Acknowledge message - we may need one
@@ -274,8 +272,7 @@ diag_l2_vag_block_recv(struct diag_l2_conn *d_l2_conn, int *errval, int msg_time
  * Will store the received telegram in the d_l2_conn->diag_msg.
  */
 int
-diag_l2_vag_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
-{
+diag_l2_vag_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout) {
 	struct diag_l2_vag *dp = (struct diag_l2_vag *)d_l2_conn->diag_l2_proto_data;
 	struct diag_msg ack;
 	unsigned long long elapsed_time, msg_timeout;
@@ -401,8 +398,7 @@ diag_l2_vag_int_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout)
 
 static int
 dl2p_vag_startcomms(struct diag_l2_conn *d_l2_conn, UNUSED(flag_type flags),
-                             unsigned int bitrate, target_type target, UNUSED(source_type source))
-{
+                             unsigned int bitrate, target_type target, UNUSED(source_type source)) {
 	struct diag_serial_settings set;
 	struct diag_l2_vag *dp;
 	int rv;
@@ -519,8 +515,7 @@ dl2p_vag_startcomms(struct diag_l2_conn *d_l2_conn, UNUSED(flag_type flags),
 }
 
 //free what _startcomms alloc'ed
-static int dl2p_vag_stopcomms(struct diag_l2_conn *d_l2_conn)
-{
+static int dl2p_vag_stopcomms(struct diag_l2_conn *d_l2_conn) {
 	//according to SAE J2818 if we want to finish the session
 	//we should just stop sending anything and let the ECU timeout;
 	//but of course l3 can implement the endcomms SID
@@ -546,8 +541,7 @@ static int dl2p_vag_stopcomms(struct diag_l2_conn *d_l2_conn)
  * Sends a single Block (message) to the ECU
  */
 static int
-dl2p_vag_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
-{
+dl2p_vag_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg) {
 	int rv = 0;
 
 	if (diag_l2_debug & DIAG_DEBUG_WRITE)
@@ -671,8 +665,7 @@ dl2p_vag_send(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg)
 static int
 dl2p_vag_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
                        void (*callback)(void *handle, struct diag_msg *msg),
-                       void *handle)
-{
+                       void *handle) {
 	int rv;
 
 	if(diag_l2_debug & DIAG_DEBUG_PROTO && timeout != 0)
@@ -718,8 +711,7 @@ dl2p_vag_recv(struct diag_l2_conn *d_l2_conn, unsigned int timeout,
 }
 
 static struct diag_msg *
-dl2p_vag_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg, int *errval)
-{
+dl2p_vag_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg, int *errval) {
 	int rv, na_retry_cnt = 0;
 	struct diag_msg *rmsg;
 	struct diag_l2_vag *dp = (struct diag_l2_vag *)d_l2_conn->diag_l2_proto_data;
@@ -781,8 +773,7 @@ dl2p_vag_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg, int *errv
  * so send it a keepalive message now.
  */
 static void
-dl2p_vag_timeout(struct diag_l2_conn *d_l2_conn)
-{
+dl2p_vag_timeout(struct diag_l2_conn *d_l2_conn) {
 	struct diag_msg ack;
 	memset(&ack, 0, sizeof(ack));
 	ack.type = KWP1281_SID_ACK;

--- a/scantool/diag_l2_vag.c
+++ b/scantool/diag_l2_vag.c
@@ -159,8 +159,7 @@ diag_l2_vag_block_recv(struct diag_l2_conn *d_l2_conn, int *errval, int msg_time
 					//and go on with the regular code path
 					dp->rxoffset = 0;
 				}
-			}
-			else {
+			} else {
 				*errval = rv;
 				return diag_pseterr(rv);
 			}

--- a/scantool/diag_l3.c
+++ b/scantool/diag_l3.c
@@ -184,7 +184,7 @@ int diag_l3_ioctl(struct diag_l3_conn *d_l3_conn, unsigned int cmd, void *data) 
 struct diag_msg *
 diag_l3_request(struct diag_l3_conn *dl3c, struct diag_msg *txmsg, int *errval) {
 	struct diag_msg *rxmsg;
-	const struct diag_l3_proto * dl3p = dl3c->d_l3_proto;
+	const struct diag_l3_proto *dl3p = dl3c->d_l3_proto;
 
 	if (diag_l3_debug & DIAG_DEBUG_WRITE)
 		fprintf(stderr,
@@ -275,8 +275,8 @@ diag_l3_base_recv(struct diag_l3_conn *d_l3_conn,
 //this implementation is rather naive and untested. It simply forwards the
 //txmsg straight to the L2 request function and returns the response msg
 //as-is.
-struct diag_msg * diag_l3_base_request(struct diag_l3_conn *dl3c,
-	struct diag_msg* txmsg, int* errval) {
+struct diag_msg *diag_l3_base_request(struct diag_l3_conn *dl3c,
+	struct diag_msg *txmsg, int *errval) {
 
 	struct diag_msg *rxmsg = NULL;
 

--- a/scantool/diag_l3.c
+++ b/scantool/diag_l3.c
@@ -44,8 +44,7 @@ static struct diag_l3_conn	*diag_l3_list;
 
 
 struct diag_l3_conn *
-diag_l3_start(const char *protocol, struct diag_l2_conn *d_l2_conn)
-{
+diag_l3_start(const char *protocol, struct diag_l2_conn *d_l2_conn) {
 	struct diag_l3_conn *d_l3_conn = NULL;
 	unsigned int i;
 	int rv;
@@ -61,8 +60,7 @@ diag_l3_start(const char *protocol, struct diag_l2_conn *d_l2_conn)
 	/* Find the protocol */
 	dp = NULL;
 	for (i=0; diag_l3_protocols[i]; i++) {
-		if (strcasecmp(protocol, diag_l3_protocols[i]->proto_name) == 0)
-		{
+		if (strcasecmp(protocol, diag_l3_protocols[i]->proto_name) == 0) {
 			dp = diag_l3_protocols[i];	/* Found. */
 			break;
 		}
@@ -117,8 +115,7 @@ diag_l3_start(const char *protocol, struct diag_l2_conn *d_l2_conn)
 }
 
 
-int diag_l3_stop(struct diag_l3_conn *d_l3_conn)
-{
+int diag_l3_stop(struct diag_l3_conn *d_l3_conn) {
 	int rv;
 
 	assert(d_l3_conn != NULL);
@@ -135,8 +132,7 @@ int diag_l3_stop(struct diag_l3_conn *d_l3_conn)
 	return rv? diag_iseterr(rv):0;
 }
 
-int diag_l3_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg)
-{
+int diag_l3_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg) {
 	int rv;
 	const struct diag_l3_proto *dp = d_l3_conn->d_l3_proto;
 
@@ -149,8 +145,7 @@ int diag_l3_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg)
 }
 
 int diag_l3_recv(struct diag_l3_conn *d_l3_conn, unsigned int timeout,
-	void (* rcv_call_back)(void *handle ,struct diag_msg *) , void *handle)
-{
+	void (* rcv_call_back)(void *handle ,struct diag_msg *) , void *handle) {
 	const struct diag_l3_proto *dp = d_l3_conn->d_l3_proto;
 	int rv;
 
@@ -166,8 +161,7 @@ int diag_l3_recv(struct diag_l3_conn *d_l3_conn, unsigned int timeout,
 
 
 void diag_l3_decode(struct diag_l3_conn *d_l3_conn,
-	struct diag_msg *msg, char *buf, const size_t bufsize)
-{
+	struct diag_msg *msg, char *buf, const size_t bufsize) {
 	const struct diag_l3_proto *dp = d_l3_conn->d_l3_proto;
 
 	dp->diag_l3_proto_decode(d_l3_conn, msg, buf, bufsize);
@@ -175,8 +169,7 @@ void diag_l3_decode(struct diag_l3_conn *d_l3_conn,
 }
 
 
-int diag_l3_ioctl(struct diag_l3_conn *d_l3_conn, unsigned int cmd, void *data)
-{
+int diag_l3_ioctl(struct diag_l3_conn *d_l3_conn, unsigned int cmd, void *data) {
 	const struct diag_l3_proto *dp = d_l3_conn->d_l3_proto;
 
 	/* Call the L3 ioctl routine if applicable */
@@ -189,8 +182,7 @@ int diag_l3_ioctl(struct diag_l3_conn *d_l3_conn, unsigned int cmd, void *data)
 
 
 struct diag_msg *
-diag_l3_request(struct diag_l3_conn *dl3c, struct diag_msg *txmsg, int *errval)
-{
+diag_l3_request(struct diag_l3_conn *dl3c, struct diag_msg *txmsg, int *errval) {
 	struct diag_msg *rxmsg;
 	const struct diag_l3_proto * dl3p = dl3c->d_l3_proto;
 
@@ -225,8 +217,7 @@ diag_l3_request(struct diag_l3_conn *dl3c, struct diag_msg *txmsg, int *errval)
  * XXX This calls non async-signal-safe functions!
  */
 
-void diag_l3_timer(void)
-{
+void diag_l3_timer(void) {
 	/*
 	 * Regular timer routine
 	 * Call protocol specific timer
@@ -256,20 +247,17 @@ void diag_l3_timer(void)
 /* Base implementations for some functions */
 
 
-int diag_l3_base_start(UNUSED(struct diag_l3_conn *d_l3_conn))
-{
+int diag_l3_base_start(UNUSED(struct diag_l3_conn *d_l3_conn)) {
 	return 0;
 }
 
 
-int diag_l3_base_stop(UNUSED(struct diag_l3_conn *d_l3_conn))
-{
+int diag_l3_base_stop(UNUSED(struct diag_l3_conn *d_l3_conn)) {
 	return 0;
 }
 
 int diag_l3_base_send(struct diag_l3_conn *d_l3_conn,
-	UNUSED(struct diag_msg *msg))
-{
+	UNUSED(struct diag_msg *msg)) {
 	d_l3_conn->timer=diag_os_getms();
 	return 0;
 }
@@ -279,8 +267,7 @@ int
 diag_l3_base_recv(struct diag_l3_conn *d_l3_conn,
 	UNUSED(unsigned int timeout),
 	UNUSED(void (* rcv_call_back)(void *handle ,struct diag_msg *)),
-	UNUSED(void *handle))
-{
+	UNUSED(void *handle)) {
 	d_l3_conn->timer=diag_os_getms();
 	return 0;
 }

--- a/scantool/diag_l3.h
+++ b/scantool/diag_l3.h
@@ -85,13 +85,13 @@ struct diag_l3_proto {
 	int (*diag_l3_proto_ioctl)(struct diag_l3_conn *, int cmd, void *data);
 
 	//proto_request : send request and return a new message with the reply, and error in *errval (0 if ok)
-	struct diag_msg * (*diag_l3_proto_request)(struct diag_l3_conn*,
-		struct diag_msg* txmsg, int* errval);
+	struct diag_msg *(*diag_l3_proto_request)(struct diag_l3_conn *,
+		struct diag_msg *txmsg, int *errval);
 
 	/* Decode msg to printable text in *buf */
 	void (*diag_l3_proto_decode)(struct diag_l3_conn *,
 		struct diag_msg *msg,
-		char * buf,
+		char *buf,
 		const size_t bufsize);
 
 	/* Timer (optional)
@@ -111,7 +111,7 @@ struct diag_l3_proto {
  * make sure to diag_l3_stop afterwards to free() the diag_l3_conn !
  * This adds the new l3 connection to the diag_l3_list linked-list
  */
-struct diag_l3_conn * diag_l3_start(const char *protocol, struct diag_l2_conn *d_l2_conn);
+struct diag_l3_conn *diag_l3_start(const char *protocol, struct diag_l2_conn *d_l2_conn);
 
 /** Stop L3 connection
  *
@@ -172,8 +172,8 @@ int diag_l3_base_recv(struct diag_l3_conn *, unsigned int,
 	void (* rcv_call_back)(void *handle ,struct diag_msg *) , void *);
 //XXX diag_l3_base_ioctl : there's no code for this one ?
 //int diag_l3_base_ioctl(struct diag_l3_conn *, int cmd, void *data);
-struct diag_msg * diag_l3_base_request(struct diag_l3_conn *dl3c,
-	struct diag_msg* txmsg, int* errval);
+struct diag_msg *diag_l3_base_request(struct diag_l3_conn *dl3c,
+	struct diag_msg *txmsg, int *errval);
 
 
 

--- a/scantool/diag_l3.h
+++ b/scantool/diag_l3.h
@@ -36,8 +36,7 @@ struct diag_msg;
 
 /** Layer 3 connection info
  */
-struct diag_l3_conn
-{
+struct diag_l3_conn {
 	struct diag_l2_conn	*d_l3l2_conn;
 	int d_l3l2_flags;		/* Flags from L2 */
 	uint32_t d_l3l1_flags;		/* Flags from L1 */

--- a/scantool/diag_l3_iso14230.c
+++ b/scantool/diag_l3_iso14230.c
@@ -51,8 +51,7 @@ static const char *l3_iso14230_neglookup(const int id);
  */
 char *
 diag_l3_iso14230_decode_response(struct diag_msg *msg,
-	char *buf, const size_t bufsize)
-{
+	char *buf, const size_t bufsize) {
 	char buf2[80];
 
 	switch (msg->data[0]) {
@@ -124,8 +123,7 @@ diag_l3_iso14230_decode_response(struct diag_msg *msg,
 //proto over an iso14230 L2 proto. Running an iso14230 L3 over anything other
 //than iso14230 is meaningless.
 static int
-diag_l3_iso14230_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg)
-{
+diag_l3_iso14230_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg) {
 	int rv;
 	struct diag_l2_conn *d_conn;
 
@@ -152,8 +150,7 @@ diag_l3_iso14230_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg)
  * call L3 callback routine
  */
 static void
-diag_l3_14230_rxcallback(void *handle, struct diag_msg *msg)
-{
+diag_l3_14230_rxcallback(void *handle, struct diag_msg *msg) {
 	/*
 	 * Got some data from L2, build it into a L3 message, if
 	 * message is complete call next layer callback routine
@@ -227,8 +224,7 @@ diag_l3_iso14230_recv(struct diag_l3_conn *d_l3_conn, unsigned int timeout,
 
 void
 diag_l3_iso14230_decode(UNUSED(struct diag_l3_conn *d_l3_conn),
-struct diag_msg *msg, char *buf, size_t bufsize)
-{
+struct diag_msg *msg, char *buf, size_t bufsize) {
 	if (msg->data[0] & 0x40)
 		snprintf(buf, bufsize, "ISO14230 response ");
 	else
@@ -241,12 +237,10 @@ struct diag_msg *msg, char *buf, size_t bufsize)
 /*
  * Table of english descriptions of the ISO14230 SIDs
  */
-static const struct
-{
+static const struct {
 	const int id;
 	const char *service;
-} sids[] =
-{
+} sids[] = {
 	{DIAG_KW2K_SI_STADS, 	"startDiagnosticSession"},
 	{DIAG_KW2K_SI_ER, 	"ecuReset"},
 	{DIAG_KW2K_SI_RDFFD, 	"readFreezeFrameData"},
@@ -285,8 +279,7 @@ static const struct
 	{DIAG_KW2K_SI_ATP, 	"accessTimingParameters"},
 };
 
-static const char *l3_iso14230_sidlookup(const int id)
-{
+static const char *l3_iso14230_sidlookup(const int id) {
 	unsigned i;
 	for (i = 0; i < ARRAY_SIZE(sids); i++)
 		if (sids[i].id == id)
@@ -299,12 +292,10 @@ static const char *l3_iso14230_sidlookup(const int id)
 /*
  * Table of english descriptions of the ISO14230 NegResponse codes
  */
-static const struct
-{
+static const struct {
 	const int id;
 	const char *response;
-} negresps[] =
-{
+} negresps[] = {
 	{DIAG_KW2K_RC_GR,	"generalReject"},
 	{DIAG_KW2K_RC_SNS,	"serviceNotSupported"},
 	{DIAG_KW2K_RC_SFNS_IF,	"subFunctionNotSupported-Invalid Format"},
@@ -336,8 +327,7 @@ static const struct
 	{0, 			NULL},
 };
 
-static const char *l3_iso14230_neglookup(const int id)
-{
+static const char *l3_iso14230_neglookup(const int id) {
 	unsigned i;
 	for (i = 0; i < ARRAY_SIZE(negresps); i++)
 		if (negresps[i].id == id)

--- a/scantool/diag_l3_saej1979.c
+++ b/scantool/diag_l3_saej1979.c
@@ -57,8 +57,7 @@ struct l3_j1979_int {
  * Get this wrong and all will fail, it's used to frame the incoming messages
  * properly
  */
-static int diag_l3_j1979_getlen(uint8_t *data, int len)
-{
+static int diag_l3_j1979_getlen(uint8_t *data, int len) {
 	static const int rqst_lengths[] = { -1, 2, 3, 1, 1, 2, 2, 1, 7, 2 };
 	int rv;
 	uint8_t mode;
@@ -218,8 +217,7 @@ static int diag_l3_j1979_getlen(uint8_t *data, int len)
  * aren't any headers.
  */
 static int
-diag_l3_j1979_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg)
-{
+diag_l3_j1979_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg) {
 	int rv;
 	struct diag_l2_conn *d_conn;
 	struct l3_j1979_int *l3i = d_l3_conn->l3_int;
@@ -258,8 +256,7 @@ diag_l3_j1979_send(struct diag_l3_conn *d_l3_conn, struct diag_msg *msg)
  * call L3 callback routine
  */
 static void
-diag_l3_rcv_callback(void *handle, struct diag_msg *msg)
-{
+diag_l3_rcv_callback(void *handle, struct diag_msg *msg) {
 	/*
 	 * Got some data from L2, build it into a L3 message, if
 	 * message is complete call next layer callback routine
@@ -304,8 +301,7 @@ diag_l3_rcv_callback(void *handle, struct diag_msg *msg)
  *
  */
 static void
-diag_l3_j1979_process_data(struct diag_l3_conn *d_l3_conn)
-{
+diag_l3_j1979_process_data(struct diag_l3_conn *d_l3_conn) {
 	/* Process the received data into messages if complete */
 	struct diag_msg *msg;
 	int sae_msglen;
@@ -402,8 +398,7 @@ diag_l3_j1979_process_data(struct diag_l3_conn *d_l3_conn)
  */
 static int
 diag_l3_j1979_recv(struct diag_l3_conn *d_l3_conn, unsigned int timeout,
-	void (* rcv_call_back)(void *handle ,struct diag_msg *) , void *handle)
-{
+	void (* rcv_call_back)(void *handle ,struct diag_msg *) , void *handle) {
 	int rv;
 	struct diag_msg *msg;
 	unsigned int tout;
@@ -541,8 +536,7 @@ diag_l3_j1979_recv(struct diag_l3_conn *d_l3_conn, unsigned int timeout,
 
 void
 diag_l3_j1979_decode(UNUSED(struct diag_l3_conn *d_l3_conn),
-struct diag_msg *msg, char *buf, size_t bufsize)
-{
+struct diag_msg *msg, char *buf, size_t bufsize) {
 	unsigned i, j;
 
 	char buf2[80];
@@ -685,8 +679,7 @@ struct diag_msg *msg, char *buf, size_t bufsize)
 		default:
 			snprintf(buf2, sizeof(buf2),"UnknownType 0x%02X: Data Dump: ", msg->data[0]);
 			smartcat(buf, bufsize, buf2);
-			for (i=0; i < msg->len; i++)
-			{
+			for (i=0; i < msg->len; i++) {
 				snprintf(buf2, sizeof(buf2), "0x%02X ", msg->data[i]);
 				smartcat(buf, bufsize, buf2);
 			}
@@ -698,7 +691,7 @@ struct diag_msg *msg, char *buf, size_t bufsize)
 //Send a service 1, pid 0 request and check for a valid reply.
 //ret 0 if ok
 static int diag_l3_j1979_keepalive(struct diag_l3_conn *d_l3_conn) {
-	struct diag_msg msg={0};
+	struct diag_msg msg = {0};
 	struct diag_msg *rxmsg;
 	uint8_t data[6];
 	int errval;
@@ -785,8 +778,7 @@ int dl3_j1979_stop(struct diag_l3_conn *d_l3_conn) {
  * return 0 if ok
  */
 static int
-diag_l3_j1979_timer(struct diag_l3_conn *d_l3_conn, unsigned long ms)
-{
+diag_l3_j1979_timer(struct diag_l3_conn *d_l3_conn, unsigned long ms) {
 	int rv;
 	int debug_l2_orig=diag_l2_debug;	//save debug flags; disable them for this procedure
 	int debug_l1_orig=diag_l1_debug;

--- a/scantool/diag_l3_vag.c
+++ b/scantool/diag_l3_vag.c
@@ -48,8 +48,7 @@
  *
  */
 static int
-diag_l3_vag_start(struct diag_l3_conn *d_l3_conn)
-{
+diag_l3_vag_start(struct diag_l3_conn *d_l3_conn) {
 	struct diag_l2_data l2data;
 	struct diag_l2_conn *d_l2_conn;
 
@@ -81,8 +80,7 @@ diag_l3_vag_start(struct diag_l3_conn *d_l3_conn)
 
 void
 diag_l3_vag_decode(UNUSED(struct diag_l3_conn *d_l3_conn),
-struct diag_msg *msg, char *buf, size_t bufsize)
-{
+struct diag_msg *msg, char *buf, size_t bufsize) {
 	char buf2[128];
 	char buf3[16];
 	const char *s;

--- a/scantool/diag_l7_d2.c
+++ b/scantool/diag_l7_d2.c
@@ -71,8 +71,7 @@ enum {
  * Indicates whether a response was a positive acknowledgement of the request.
  */
 static bool
-success_p(struct diag_msg *req, struct diag_msg *resp)
-{
+success_p(struct diag_msg *req, struct diag_msg *resp) {
 	if (resp->len < 1)
 		return false;
 
@@ -89,8 +88,7 @@ success_p(struct diag_msg *req, struct diag_msg *resp)
  * Verify communication with the ECU.
  */
 int
-diag_l7_d2_ping(struct diag_l2_conn *d_l2_conn)
-{
+diag_l7_d2_ping(struct diag_l2_conn *d_l2_conn) {
 	uint8_t req[] = { testerPresent };
 	int errval = 0;
 	struct diag_msg msg = {0};
@@ -114,8 +112,7 @@ diag_l7_d2_ping(struct diag_l2_conn *d_l2_conn)
 
 /* The request message for reading memory */
 static int
-read_MEMORY_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, uint8_t count)
-{
+read_MEMORY_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, uint8_t count) {
 	static uint8_t req[] = { readMemoryByAddress, 0, 99, 99, 1, 99 };
 
 	req[2] = (addr>>8)&0xff;
@@ -128,8 +125,7 @@ read_MEMORY_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, uint8_t c
 
 /* The request message for reading live data by 1-byte identifier */
 static int
-read_LIVEDATA_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_t count))
-{
+read_LIVEDATA_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_t count)) {
 	static uint8_t req[] = { readDataByLocalIdentifier, 99, 1 };
 
 	req[1] = addr&0xff;
@@ -145,8 +141,7 @@ read_LIVEDATA_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(
 
 /* The request message for reading live data by 2-byte ident (CAN bus only?) */
 static int
-read_LIVEDATA2_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_t count))
-{
+read_LIVEDATA2_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_t count)) {
 	static uint8_t req[] = { readDataByLongLocalIdentifier, 99, 99, 1 };
 	req[1] = (addr>>8)&0xff;
 	req[2] = addr&0xff;
@@ -157,8 +152,7 @@ read_LIVEDATA2_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED
 
 /* The request message for reading non-volatile data */
 static int
-read_NV_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_t count))
-{
+read_NV_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_t count)) {
 	static uint8_t req[] = { readNVByLocalIdentifier, 99 };
 
 	req[1] = addr&0xff;
@@ -174,8 +168,7 @@ read_NV_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_
 
 /* The request message for reading freeze frames */
 static int
-read_FREEZE_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_t count))
-{
+read_FREEZE_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(uint8_t count)) {
 	static uint8_t req[] = { readFreezeFrameByDTC, 99, 0 };
 
 	req[1] = addr&0xff;
@@ -202,8 +195,7 @@ read_FREEZE_req(uint8_t **msgout, unsigned int *msglen, uint16_t addr, UNUSED(ui
  * be more or less than the number of bytes requested.
  */
 int
-diag_l7_d2_read(struct diag_l2_conn *d_l2_conn, enum namespace ns, uint16_t addr, int buflen, uint8_t *out)
-{
+diag_l7_d2_read(struct diag_l2_conn *d_l2_conn, enum namespace ns, uint16_t addr, int buflen, uint8_t *out) {
 	struct diag_msg req = {0};
 	struct diag_msg *resp = NULL;
 	int datalen;
@@ -263,8 +255,7 @@ diag_l7_d2_read(struct diag_l2_conn *d_l2_conn, enum namespace ns, uint16_t addr
  * Retrieve list of stored DTCs.
  */
 int
-diag_l7_d2_dtclist(struct diag_l2_conn *d_l2_conn, int buflen, uint8_t *out)
-{
+diag_l7_d2_dtclist(struct diag_l2_conn *d_l2_conn, int buflen, uint8_t *out) {
 	uint8_t req[] = { readDiagnosticTroubleCodes, 1 };
 	int errval = 0;
 	struct diag_msg msg = {0};
@@ -308,8 +299,7 @@ diag_l7_d2_dtclist(struct diag_l2_conn *d_l2_conn, int buflen, uint8_t *out)
  * ECU returned positive acknowledgement for the clear request, <0 for errors.
  */
 int
-diag_l7_d2_cleardtc(struct diag_l2_conn *d_l2_conn)
-{
+diag_l7_d2_cleardtc(struct diag_l2_conn *d_l2_conn) {
 	uint8_t req[] = { clearDiagnosticInformation, 1 };
 	uint8_t buf[1];
 	struct diag_msg msg = {0};
@@ -349,8 +339,7 @@ diag_l7_d2_cleardtc(struct diag_l2_conn *d_l2_conn)
  * cycle depends on which output is specified.
  */
 int
-diag_l7_d2_io_control(struct diag_l2_conn *d_l2_conn, uint8_t id, uint8_t reps)
-{
+diag_l7_d2_io_control(struct diag_l2_conn *d_l2_conn, uint8_t id, uint8_t reps) {
 	uint8_t req[] = { inputOutputControlByLocalIdentifier, id, 0x32, reps };
 	struct diag_msg msg = {0};
 	struct diag_msg *resp = NULL;

--- a/scantool/diag_l7_kwp71.c
+++ b/scantool/diag_l7_kwp71.c
@@ -72,8 +72,7 @@ enum {
  * Verify communication with the ECU.
  */
 int
-diag_l7_kwp71_ping(struct diag_l2_conn *d_l2_conn)
-{
+diag_l7_kwp71_ping(struct diag_l2_conn *d_l2_conn) {
 	int errval = 0;
 	struct diag_msg msg = {0};
 	struct diag_msg *resp = NULL;
@@ -95,8 +94,7 @@ diag_l7_kwp71_ping(struct diag_l2_conn *d_l2_conn)
 
 /* The request message for reading memory */
 static int
-read_MEMORY_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr, uint8_t count)
-{
+read_MEMORY_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr, uint8_t count) {
 	static struct diag_msg msg = { 0 };
 	static uint8_t data[3];
 
@@ -113,8 +111,7 @@ read_MEMORY_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr, uint
 
 /* The request message for reading ROM */
 static int
-read_ROM_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr, uint8_t count)
-{
+read_ROM_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr, uint8_t count) {
 	static struct diag_msg msg = { 0 };
 	static uint8_t data[3];
 
@@ -131,8 +128,7 @@ read_ROM_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr, uint8_t
 
 /* The request message for taking ADC readings */
 static int
-read_ADC_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr)
-{
+read_ADC_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr) {
 	static struct diag_msg msg = { 0 };
 	static uint8_t data[1];
 
@@ -162,8 +158,7 @@ read_ADC_req(struct diag_msg **msgout, uint8_t *wantresp, uint16_t addr)
  * bytes requested. Returns the actual byte count received.
  */
 int
-diag_l7_kwp71_read(struct diag_l2_conn *d_l2_conn, enum namespace ns, uint16_t addr, int buflen, uint8_t *out)
-{
+diag_l7_kwp71_read(struct diag_l2_conn *d_l2_conn, enum namespace ns, uint16_t addr, int buflen, uint8_t *out) {
 	struct diag_msg *req;
 	struct diag_msg *resp = NULL;
 	uint8_t wantresp;
@@ -217,8 +212,7 @@ diag_l7_kwp71_read(struct diag_l2_conn *d_l2_conn, enum namespace ns, uint16_t a
  * small for the full response.
  */
 int
-diag_l7_kwp71_dtclist(struct diag_l2_conn *d_l2_conn, int buflen, uint8_t *out)
-{
+diag_l7_kwp71_dtclist(struct diag_l2_conn *d_l2_conn, int buflen, uint8_t *out) {
 	int errval = 0;
 	struct diag_msg msg = {0};
 	struct diag_msg *resp = NULL;
@@ -263,8 +257,7 @@ diag_l7_kwp71_dtclist(struct diag_l2_conn *d_l2_conn, int buflen, uint8_t *out)
  * ECU returned positive acknowledgement for the clear request, <0 for errors.
  */
 int
-diag_l7_kwp71_cleardtc(struct diag_l2_conn *d_l2_conn)
-{
+diag_l7_kwp71_cleardtc(struct diag_l2_conn *d_l2_conn) {
 	uint8_t buf[1];
 	struct diag_msg msg = {0};
 	struct diag_msg *resp = NULL;

--- a/scantool/diag_os.h
+++ b/scantool/diag_os.h
@@ -81,7 +81,7 @@ void diag_os_calibrate(void);
  * @note Caller must not free() the string.
  * This should only be used from OS-specific code ! (diag_os*.c and diag_tty_*.c )
  */
-const char * diag_os_geterr(OS_ERRTYPE os_errno);
+const char *diag_os_geterr(OS_ERRTYPE os_errno);
 
 /* Scheduler */
 int diag_os_sched(void);

--- a/scantool/diag_os_unix.c
+++ b/scantool/diag_os_unix.c
@@ -478,7 +478,7 @@ diag_os_sched(void) {
 //Either gets the last error if os_errno==0, or print the
 //message associated with the specified os_errno
 // XXX this is not async-safe / re-entrant !
-const char * diag_os_geterr(OS_ERRTYPE os_errno) {
+const char *diag_os_geterr(OS_ERRTYPE os_errno) {
 	//we'll suppose strerr is satisfactory.
 	return (const char *) strerror(os_errno? os_errno : errno);
 //	static char errbuf[30];
@@ -490,7 +490,7 @@ const char * diag_os_geterr(OS_ERRTYPE os_errno) {
 
 #ifdef _POSIX_TIMERS
 //internal use. ret 0 if ok
-static int diag_os_testgt(clockid_t ckid, char * ckname) {
+static int diag_os_testgt(clockid_t ckid, char *ckname) {
 	struct timespec tmtest;
 	if (clock_gettime(ckid, &tmtest) == 0) {
 		printf("clock_gettime(): using %s\n", ckname);
@@ -500,7 +500,7 @@ static int diag_os_testgt(clockid_t ckid, char * ckname) {
 	return -1;
 }
 //internal use. ret 0 if ok
-static int diag_os_testns(clockid_t ckid, char * ckname) {
+static int diag_os_testns(clockid_t ckid, char *ckname) {
 	struct timespec rqtp;
 	rqtp.tv_sec = 0;
 	rqtp.tv_nsec = 0;	//bogus interval for nanosleep test

--- a/scantool/diag_os_unix.c
+++ b/scantool/diag_os_unix.c
@@ -117,11 +117,10 @@ static pthread_mutex_t periodic_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static void
 #if defined(_POSIX_TIMERS) && (SEL_PERIODIC==S_POSIX || SEL_PERIODIC==S_AUTO)
-diag_os_periodic(UNUSED(union sigval sv))
+diag_os_periodic(UNUSED(union sigval sv)) {
 #else
-diag_os_periodic(UNUSED(int unused))
+diag_os_periodic(UNUSED(int unused)) {
 #endif
-{
 	/* Warning: these indirectly use non-async-signal-safe functions
 	* Their behavior is undefined if they happen
 	* to occur during any other non-async-signal-safe function.
@@ -137,8 +136,7 @@ diag_os_periodic(UNUSED(int unused))
 //for keepalive messages, and selects + calibrates timer functions.
 //return 0 if ok
 int
-diag_os_init(void)
-{
+diag_os_init(void) {
 	const long tmo = ALARM_TIMEOUT;
 
 	if (diag_os_init_done)
@@ -237,7 +235,7 @@ int diag_os_close() {
 	timer_delete(ptimer_id);
 #else
 	//stop the interval timer:
-	struct itimerval tv={{0,0},{0, 0}};
+	struct itimerval tv = {{0,0},{0, 0}};
 	setitimer(ITIMER_REAL, &tv, 0);
 
 	//and  set the SIGALRM handler to default, whatever that is
@@ -255,8 +253,7 @@ int diag_os_close() {
 
 //return after (ms) milliseconds.
 void
-diag_os_millisleep(unsigned int ms)
-{
+diag_os_millisleep(unsigned int ms) {
 	unsigned long long t1,t2;	//for verification
 	long int offsetus;
 
@@ -415,8 +412,7 @@ diag_os_ipending(void) {
 //will harm nothing. There is no "opposite" function of this, to
 //reset normal priority.
 int
-diag_os_sched(void)
-{
+diag_os_sched(void) {
 	static int os_sched_done=0;
 	int rv=0;
 
@@ -428,8 +424,7 @@ diag_os_sched(void)
 	/*
 	 * Check privileges
 	 */
-	if (getuid() != 0)
-	{
+	if (getuid() != 0) {
 		static int suser_warned;
 		if (suser_warned == 0) {
 			suser_warned = 1;
@@ -445,8 +440,7 @@ diag_os_sched(void)
 
 		/* Set real time UNIX scheduling */
 		p.sched_priority = 1;
-		if ( sched_setscheduler(getpid(), SCHED_FIFO, &p) < 0)
-		{
+		if ( sched_setscheduler(getpid(), SCHED_FIFO, &p) < 0) {
 			fprintf(stderr, FLFMT "sched_setscheduler failed: %s.\n",
 				FL, strerror(errno));
 			r = -1;
@@ -676,7 +670,7 @@ unsigned long long diag_os_gethrt(void) {
 	assert(discover_done);
 #if defined(_POSIX_TIMERS) && (SEL_HRT==S_POSIX || SEL_HRT==S_AUTO)
 	//units : ns
-	struct timespec curtime={0};
+	struct timespec curtime = {0};
 
 	clock_gettime(clkid_gt, &curtime);
 

--- a/scantool/diag_os_win.c
+++ b/scantool/diag_os_win.c
@@ -263,7 +263,7 @@ diag_os_sched(void) {
 //message associated with the specified os_errno
 // XXX this is not async-safe / re-entrant !
 //
-const char * diag_os_geterr(OS_ERRTYPE os_errno) {
+const char *diag_os_geterr(OS_ERRTYPE os_errno) {
 	//to make this re-entrant, we would need CreateMutex OpenMutex etc.
 	static char errbuf[160]="";
 

--- a/scantool/diag_os_win.c
+++ b/scantool/diag_os_win.c
@@ -37,7 +37,7 @@
 
 static int diag_os_init_done=0;
 
-LARGE_INTEGER perfo_freq={{0,0}};	//for use with QueryPerformanceFrequency and QueryPerformanceCounter
+LARGE_INTEGER perfo_freq = {{0,0}};	//for use with QueryPerformanceFrequency and QueryPerformanceCounter
 float pf_conv=0;		//this will be (1E6 / perfo_freq) to convert counts to microseconds, i.e. [us]=[counts]*pf_conv
 static int pfconv_valid=0;	//flag after querying perfo_freq; nothing will not work without a performance counter
 int shortsleep_reliable=0;	//TODO : auto-detect this on startup. See diag_os_millisleep & diag_os_calibrate
@@ -74,8 +74,7 @@ VOID CALLBACK timercallback(UNUSED(PVOID lpParam), BOOLEAN timedout) {
 //calls diag_os_sched to increase thread priority.
 //return 0 if ok
 int
-diag_os_init(void)
-{
+diag_os_init(void) {
 	unsigned long tmo=ALARM_TIMEOUT;
 
 	if (diag_os_init_done)
@@ -166,8 +165,7 @@ goodexit:
 
 //
 void
-diag_os_millisleep(unsigned int ms)
-{
+diag_os_millisleep(unsigned int ms) {
 	//This version self-corrects if Sleep() overshoots;
 	//if it undershoots then we run an empty loop for the remaining
 	//time. Eventually "correction" should contain the biggest
@@ -232,8 +230,7 @@ diag_os_ipending(void) {
 //reset normal priority.
 //we ifdef the body of the function according to the OS capabilities
 int
-diag_os_sched(void)
-{
+diag_os_sched(void) {
 	static int os_sched_done=0;
 	int rv=0;
 

--- a/scantool/diag_test.c
+++ b/scantool/diag_test.c
@@ -77,8 +77,7 @@ static bool run_tests(void) {
 
 
 int
-main(int argc,  char **argv)
-{
+main(int argc,  char **argv) {
 	bool rv;
 	(void) argc;
 	(void) argv;

--- a/scantool/diag_tty.h
+++ b/scantool/diag_tty.h
@@ -54,13 +54,13 @@ typedef void ttyp;	//used as "(tty_internal_struct *) ttyp" in tty code
  * strlist_free()
  *
  */
-char ** diag_tty_getportlist(int *numports);
+char **diag_tty_getportlist(int *numports);
 
 /** Open serial port
  * @param portname: serial port device / file / tty name
  * @return new ttyp handle if ok, NULL if failed
  */
-ttyp * diag_tty_open(const char *portname);
+ttyp *diag_tty_open(const char *portname);
 
 /** Close serial port
  *

--- a/scantool/diag_tty_unix.c
+++ b/scantool/diag_tty_unix.c
@@ -46,16 +46,14 @@
 #if defined(_POSIX_TIMERS) && (SEL_TIMEOUT==S_POSIX || SEL_TIMEOUT==S_AUTO)
 #define PT_REPEAT	1000	//after the nominal timeout period the timer will expire every PT_REPEAT us.
 static void
-diag_tty_rw_timeout_handler(UNUSED(int sig), siginfo_t *si, UNUSED(void *uc))
-{
+diag_tty_rw_timeout_handler(UNUSED(int sig), siginfo_t *si, UNUSED(void *uc)) {
 	assert(si->si_value.sival_ptr != NULL);
 	((struct unix_tty_int *)(si->si_value.sival_ptr))->pt_expired = 1;
 	return;
 }
 #endif
 
-ttyp * diag_tty_open(const char *portname)
-{
+ttyp * diag_tty_open(const char *portname) {
 	int rv;
 	struct unix_tty_int *uti;
 #if defined(_POSIX_TIMERS) && (SEL_TIMEOUT==S_POSIX || SEL_TIMEOUT==S_AUTO)
@@ -246,8 +244,7 @@ ttyp * diag_tty_open(const char *portname)
 }
 
 /* Close up the TTY and restore. */
-void diag_tty_close(ttyp *tty_int)
-{
+void diag_tty_close(ttyp *tty_int) {
 	struct unix_tty_int *uti = tty_int;
 
 	if (!uti) return;
@@ -298,7 +295,7 @@ static int _tty_setspeed(ttyp *tty_int, unsigned int spd) {
 
 	fd = uti->fd;
 
-	const unsigned int std_table[]= {
+	const unsigned int std_table[] = {
 		0, 50, 75, 110,
 		134, 150, 200, 300,
 		600, 1200, 1800, 2400,
@@ -311,7 +308,7 @@ static int _tty_setspeed(ttyp *tty_int, unsigned int spd) {
 	#endif
 	};
 	//std_names must match speeds in std_table !
-	const speed_t std_names[]= {
+	const speed_t std_names[] = {
 		B0, B50, B75, B110,
 		B134, B150, B200, B300,
 		B600, B1200, B1800, B2400,
@@ -382,8 +379,7 @@ static int _tty_setspeed(ttyp *tty_int, unsigned int spd) {
 		ss_new.flags |= ASYNC_SPD_CUST | ASYNC_LOW_LATENCY;
 
 		/* And tell the kernel the new settings */
-		if (ioctl(fd, TIOCSSERIAL, &ss_new) < 0)
-		{
+		if (ioctl(fd, TIOCSSERIAL, &ss_new) < 0) {
 			fprintf(stderr,
 				FLFMT "setspeed(cust): ioctl failed: %s\n", FL, strerror(errno));
 			return 0;
@@ -506,8 +502,7 @@ static int _tty_setspeed(ttyp *tty_int, unsigned int spd) {
  * Set speed/parity etc, return 0 if ok
  */
 int
-diag_tty_setup(ttyp *tty_int, const struct diag_serial_settings *pset)
-{
+diag_tty_setup(ttyp *tty_int, const struct diag_serial_settings *pset) {
 	int rv;
 	int fd;
 	struct unix_tty_int *uti = tty_int;
@@ -625,8 +620,7 @@ diag_tty_setup(ttyp *tty_int, const struct diag_serial_settings *pset)
  * Set/Clear DTR and RTS lines, as specified
  */
 int
-diag_tty_control(ttyp *tty_int,  unsigned int dtr, unsigned int rts)
-{
+diag_tty_control(ttyp *tty_int,  unsigned int dtr, unsigned int rts) {
 	int flags;	/* Current flag values. */
 	struct unix_tty_int *uti = tty_int;
 	int setflags = 0, clearflags = 0;
@@ -668,9 +662,8 @@ diag_tty_control(ttyp *tty_int,  unsigned int dtr, unsigned int rts)
 // In addition, this calculates + enforces a write timeout based on the number of bytes.
 // But write timeouts should be very rare, and are considered an error
 ssize_t
-diag_tty_write(ttyp *tty_int, const void *buf, const size_t count)
+diag_tty_write(ttyp *tty_int, const void *buf, const size_t count) {
 #if defined(_POSIX_TIMERS) && (SEL_TIMEOUT==S_POSIX || SEL_TIMEOUT==S_AUTO)
-{
 	ssize_t rv;
 	struct unix_tty_int *uti = tty_int;
 	size_t n;
@@ -748,7 +741,7 @@ diag_tty_write(ttyp *tty_int, const void *buf, const size_t count)
 	/* No POSIX timers, this should be OK for everything else
 	 * Technique: write loop, manually check timeout
 	 */
-{
+
 	ssize_t rv;
 	ssize_t n;
 	size_t c = count;
@@ -810,9 +803,8 @@ diag_tty_write(ttyp *tty_int, const void *buf, const size_t count)
 
 
 ssize_t
-diag_tty_read(ttyp *tty_int, void *buf, size_t count, unsigned int timeout)
+diag_tty_read(ttyp *tty_int, void *buf, size_t count, unsigned int timeout) {
 #if defined(_POSIX_TIMERS) && (SEL_TIMEOUT==S_POSIX || SEL_TIMEOUT==S_AUTO)
-{
 	ssize_t rv;
 	size_t n;
 	int expired;
@@ -883,7 +875,7 @@ diag_tty_read(ttyp *tty_int, void *buf, size_t count, unsigned int timeout)
  //no posix timers and it's not linux
 	//Loop with { select() with a timeout;
 	// read() ; manually check timeout}
-{
+
 	ssize_t rv;
 	ssize_t n;
 	uint8_t *p;
@@ -989,7 +981,6 @@ finished:
  * Also, it calls select() very very often (why is tv={0} ?)
  */
 
-{
 	struct timeval tv;
 	unsigned int time;
 	int rv,fd,retval;
@@ -1056,12 +1047,11 @@ finished:
 	close(fd);
 
 	if (diag_l0_debug & DIAG_DEBUG_IOCTL)
-		if (time>=timeout){
+		if (time>=timeout) {
 			fprintf(stderr, FLFMT "timed out: %ums\n",FL,timeout*1000/2048);
 		}
 
-	switch (rv)
-	{
+	switch (rv) {
 	case 0:
 		/* Timeout */
 	//this doesn't require a diag_iseterr() call, as is the case when diag_tty_read
@@ -1129,8 +1119,7 @@ int diag_tty_iflush(ttyp *tty_int) {
 
 
 // ideally use TIOCSBRK, if defined (probably in sys/ioctl.h)
-int diag_tty_break(ttyp *tty_int, const unsigned int ms)
-{
+int diag_tty_break(ttyp *tty_int, const unsigned int ms) {
 #ifdef TIOCSBRK
 // TIOCSBRK: set TX break until TIOCCBRK. Ideal for our use but not in POSIX.
 /*

--- a/scantool/diag_tty_unix.c
+++ b/scantool/diag_tty_unix.c
@@ -53,7 +53,7 @@ diag_tty_rw_timeout_handler(UNUSED(int sig), siginfo_t *si, UNUSED(void *uc)) {
 }
 #endif
 
-ttyp * diag_tty_open(const char *portname) {
+ttyp *diag_tty_open(const char *portname) {
 	int rv;
 	struct unix_tty_int *uti;
 #if defined(_POSIX_TIMERS) && (SEL_TIMEOUT==S_POSIX || SEL_TIMEOUT==S_AUTO)
@@ -1260,7 +1260,7 @@ static bool test_ttyness(const char *pname) {
  * Adapted from FreeSSM :
  * https://github.com/Comer352L/FreeSSM
  */
-char ** diag_tty_getportlist(int *numports) {
+char **diag_tty_getportlist(int *numports) {
 	char ffn[256] = "";				// full filename incl. path
 	const char *devroot="/dev/";
 	const char *devusbroot="/dev/usb";

--- a/scantool/diag_tty_unix.h
+++ b/scantool/diag_tty_unix.h
@@ -115,8 +115,8 @@ extern "C" {
 
 	Could we someday have a sane way of setting integer baud rates ? pfah.
 	 */
-	extern int cfsetispeed(struct termios* __termios_p, speed_t __speed);
-	extern int cfsetospeed(struct termios* __termios_p, speed_t __speed);
+	extern int cfsetispeed(struct termios *__termios_p, speed_t __speed);
+	extern int cfsetospeed(struct termios *__termios_p, speed_t __speed);
 #else
 	#include <termios.h>	//has speed_t, tcsetattr, struct termios, cfset*speed, etc
 #endif // USE_TERMIOS2

--- a/scantool/diag_tty_win.c
+++ b/scantool/diag_tty_win.c
@@ -27,8 +27,7 @@ struct tty_int {
 };
 
 //diag_tty_open : open specified port for L0
-ttyp * diag_tty_open(const char *portname)
-{
+ttyp * diag_tty_open(const char *portname) {
 	int rv;
 	struct tty_int *wti;
 	size_t n = strlen(portname) + 1;
@@ -103,8 +102,7 @@ ttyp * diag_tty_open(const char *portname)
 } //diag_tty_open
 
 /* Close up the TTY and restore. */
-void diag_tty_close(ttyp *ttyh)
-{
+void diag_tty_close(ttyp *ttyh) {
 	struct tty_int *wti = ttyh;
 
 	if (!wti) return;
@@ -132,8 +130,7 @@ void diag_tty_close(ttyp *ttyh)
  */
 int
 diag_tty_setup(ttyp *ttyh,
-	const struct diag_serial_settings *pset)
-{
+	const struct diag_serial_settings *pset) {
 	HANDLE devhandle;		//just to clarify code
 	struct tty_int *wti = ttyh;
 	DCB *devstate;
@@ -162,8 +159,7 @@ diag_tty_setup(ttyp *ttyh,
 
 
 
-	if (diag_l0_debug & DIAG_DEBUG_IOCTL)
-	{
+	if (diag_l0_debug & DIAG_DEBUG_IOCTL) {
 		fprintf(stderr, FLFMT "dev %p; %dbps %d,%d,%d \n",
 			FL, (void *)devhandle, pset->speed,
 			pset->databits, pset->stopbits, pset->parflag);
@@ -253,8 +249,7 @@ diag_tty_setup(ttyp *ttyh,
  * ret 0 if ok
  */
 int
-diag_tty_control(ttyp *ttyh, unsigned int dtr, unsigned int rts)
-{
+diag_tty_control(ttyp *ttyh, unsigned int dtr, unsigned int rts) {
 	unsigned int escapefunc;
 	struct tty_int *wti = ttyh;
 
@@ -382,8 +377,7 @@ diag_tty_read(ttyp *ttyh, void *buf, size_t count, unsigned int timeout) {
  * ret 0 if ok
  *
  */
-int diag_tty_iflush(ttyp *ttyh)
-{
+int diag_tty_iflush(ttyp *ttyh) {
 	uint8_t buf[MAXRBUF];
 	int rv;
 	struct tty_int *wti = ttyh;

--- a/scantool/diag_tty_win.c
+++ b/scantool/diag_tty_win.c
@@ -27,7 +27,7 @@ struct tty_int {
 };
 
 //diag_tty_open : open specified port for L0
-ttyp * diag_tty_open(const char *portname) {
+ttyp *diag_tty_open(const char *portname) {
 	int rv;
 	struct tty_int *wti;
 	size_t n = strlen(portname) + 1;
@@ -546,7 +546,7 @@ int diag_tty_fastbreak(ttyp *ttyh, const unsigned int ms) {
  * https://github.com/Comer352L/FreeSSM
  */
 
-char ** diag_tty_getportlist(int *numports) {
+char **diag_tty_getportlist(int *numports) {
 	HKEY hKey;				// handle to registry key
 	DWORD index = 0;			// index registry-key: unsigned int (32bit)
 	char ValueName[256] = "";
@@ -566,10 +566,10 @@ char ** diag_tty_getportlist(int *numports) {
 	cv = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "HARDWARE\\DEVICEMAP\\SERIALCOMM", 0, KEY_READ, &hKey);
 	if (cv == ERROR_SUCCESS) {
 		while ((RegEnumValueA(hKey, index, ValueName, &szValueName, NULL, NULL,Data,&szData)) == ERROR_SUCCESS) {
-			if (!strncmp((char*)Data,"COM",3)) {
+			if (!strncmp((char *)Data,"COM",3)) {
 				// CHECK IF PORT IS AVAILABLE (not in use):
 				char NTdevName[30] = "\\\\.\\";	// => "\\.\"
-				strncpy(NTdevName+4, (char*)Data, 25);
+				strncpy(NTdevName+4, (char *)Data, 25);
 				/* NOTE: MS-DOS device names ("COMx") are not reliable if x is > 9 !!!
 					=> device can not be opened (error 2 "The system cannot find the file specified.")
 					Using NT device names instead ("\\.\COMx") which work in all cases.

--- a/scantool/dyno.c
+++ b/scantool/dyno.c
@@ -38,12 +38,10 @@
 #define MIN(_a_, _b_) (((_a_) < (_b_) ? (_a_) : (_b_)))
 
 /* generic measures table */
-struct dyno_measure_table
-{
+struct dyno_measure_table {
   int size; /* allocated size */
   int nbr;  /* number of elements in the table */
-  union     /* table of measures */
-  {
+  union {   /* table of measures */
     dyno_loss_measure * loss_measures;
     dyno_measure * measures;
   } meas;
@@ -62,18 +60,15 @@ struct dyno_measure_table measure_table;
  *****************************************************************************/
 
 /* Check table allocated size before addind a new element */
-static int dyno_check_allocated_table(struct dyno_measure_table * table, size_t elt_size)
-{
-  if (table->meas.measures == NULL)
-  {
+static int dyno_check_allocated_table(struct dyno_measure_table * table, size_t elt_size) {
+  if (table->meas.measures == NULL) {
     /* allocating the table */
     table->size = DYNO_DEFAULT_TABLE_SIZE;
     table->nbr  = 0;
     if (diag_malloc(&table->meas.measures, table->size * elt_size))
 		return DIAG_ERR_NOMEM;
   }
-  else if (table->nbr == table->size)
-  {
+  else if (table->nbr == table->size) {
     /* reallocating the table if maximum capacity is reached */
     void * ptr;
 
@@ -94,10 +89,8 @@ static int dyno_check_allocated_table(struct dyno_measure_table * table, size_t 
 }
 
 /* reset table content */
-static int dyno_table_reset(struct dyno_measure_table * table)
-{
-  if (table->meas.measures != NULL)
-  {
+static int dyno_table_reset(struct dyno_measure_table * table) {
+  if (table->meas.measures != NULL) {
     free(table->meas.measures);
     table->meas.measures = NULL;
   }
@@ -118,8 +111,7 @@ int dyno_mass;
 /*
  * Sets the mass of the vehicle
  */
-int dyno_set_mass(int mass)
-{
+int dyno_set_mass(int mass) {
   dyno_mass = mass;
   return DYNO_OK;
 }
@@ -127,8 +119,7 @@ int dyno_set_mass(int mass)
 /*
  * Gets the mass of the vehicle
  */
-int dyno_get_mass()
-{
+int dyno_get_mass() {
   return dyno_mass;
 }
 
@@ -146,8 +137,7 @@ int dyno_gear;
 /*
  * Set ratio from speed (m/s * 1000) and rpm
  */
-int dyno_set_gear(int speed, int rpm)
-{
+int dyno_set_gear(int speed, int rpm) {
   dyno_gear = speed * DYNO_GEAR_ACCURACY / rpm;
   return DYNO_OK;
 }
@@ -155,8 +145,7 @@ int dyno_set_gear(int speed, int rpm)
 /*
  * Get speed (in m/s * 1000) from rpm
  */
-int dyno_get_speed_from_rpm(int rpm)
-{
+int dyno_get_speed_from_rpm(int rpm) {
   int speed;
   speed = rpm * dyno_gear / DYNO_GEAR_ACCURACY; /* m/s * 1000 */
   return speed;
@@ -174,8 +163,7 @@ int dyno_get_speed_from_rpm(int rpm)
 int dyno_loss_needs_calculation=0;
 
 /* Add loss measure */
-int dyno_loss_add_measure(int millis, int speed)
-{
+int dyno_loss_add_measure(int millis, int speed) {
   /* check memory allocation */
   dyno_check_allocated_table(&loss_measure_table, sizeof(dyno_measure));
 
@@ -212,8 +200,7 @@ double dyno_loss_f;
  */
 
 /* get acceleration between 2 measures (m/s^2) */
-static double dyno_loss_a_inter(int i, int j)
-{
+static double dyno_loss_a_inter(int i, int j) {
   double a;
   dyno_loss_measure * measure0;
   dyno_loss_measure * measure1;
@@ -235,8 +222,7 @@ static double dyno_loss_a_inter(int i, int j)
 }
 
 /* a(i) (m/s^2) */
-static double dyno_loss_a(int i)
-{
+static double dyno_loss_a(int i) {
   double a;
 
   if (i <= 0)
@@ -250,14 +236,12 @@ static double dyno_loss_a(int i)
 }
 
 /* get y(i) */
-static double dyno_loss_y(int i)
-{
+static double dyno_loss_y(int i) {
   return (0 - dyno_mass * dyno_loss_a(i));
 }
 
 /* Calculate d and f factors */
-static int dyno_loss_calculate(void)
-{
+static int dyno_loss_calculate(void) {
   int i, nb;
   double sum;
   dyno_loss_measure * measure0;
@@ -266,8 +250,7 @@ static int dyno_loss_calculate(void)
   /* calculate d */
   nb = loss_measure_table.nbr - 1;
   sum = 0;
-  for (i=0; i<nb; i++)
-  {
+  for (i=0; i<nb; i++) {
     double d;
 
     /* select measures */
@@ -283,8 +266,7 @@ static int dyno_loss_calculate(void)
   /* calculate f */
   nb = loss_measure_table.nbr;
   sum = 0;
-  for (i=0; i<nb; i++)
-  {
+  for (i=0; i<nb; i++) {
     double f;
 
     measure0 = &loss_measure_table.meas.loss_measures[i];
@@ -300,8 +282,7 @@ static int dyno_loss_calculate(void)
 }
 
 /* Reset all dyno loss measures */
-int dyno_loss_reset()
-{
+int dyno_loss_reset() {
   dyno_table_reset(&loss_measure_table);
 
   dyno_loss_d = 0;
@@ -311,8 +292,7 @@ int dyno_loss_reset()
 }
 
 /* Get d value */
-double dyno_loss_get_d()
-{
+double dyno_loss_get_d() {
   if (dyno_loss_needs_calculation == 1)
     dyno_loss_calculate();
 
@@ -320,27 +300,23 @@ double dyno_loss_get_d()
 }
 
 /* Get f value */
-double dyno_loss_get_f()
-{
+double dyno_loss_get_f() {
   if (dyno_loss_needs_calculation == 1)
     dyno_loss_calculate();
 
   return dyno_loss_f;
 }
 
-void dyno_loss_set_d(double d)
-{
+void dyno_loss_set_d(double d) {
   dyno_loss_d = d;
 }
 
-void dyno_loss_set_f(double f)
-{
+void dyno_loss_set_f(double f) {
   dyno_loss_f = f;
 }
 
 /* Calculate loss power from speed (m/s2 * 1000) */
-static long dyno_loss_power(long speed)
-{
+static long dyno_loss_power(long speed) {
   double power;
 
   if (dyno_loss_needs_calculation == 1)
@@ -357,8 +333,7 @@ static long dyno_loss_power(long speed)
  *****************************************************************************/
 
 /* Add a measure */
-int dyno_add_measure(int millis, int rpm)
-{
+int dyno_add_measure(int millis, int rpm) {
   /* check memory allocation */
   dyno_check_allocated_table(&measure_table, sizeof(dyno_measure));
 
@@ -373,20 +348,17 @@ int dyno_add_measure(int millis, int rpm)
 }
 
 /* Reset all dyno data */
-int dyno_reset()
-{
+int dyno_reset() {
   return dyno_table_reset(&measure_table);
 }
 
 /* Get number of measures */
-int dyno_get_nb_measures()
-{
+int dyno_get_nb_measures() {
   return measure_table.nbr;
 }
 
 /* Get all measures */
-int dyno_get_measures(dyno_measure * measures, int size)
-{
+int dyno_get_measures(dyno_measure * measures, int size) {
   /* copy measures */
   memcpy(measures, measure_table.meas.measures, MIN(size, measure_table.nbr) * sizeof(dyno_measure));
 
@@ -407,8 +379,7 @@ int dyno_get_measures(dyno_measure * measures, int size)
 /*
  * Calculate power between 2 acceleration measures
  */
-static void dyno_calculate_result(dyno_measure * measure0, dyno_measure * measure1, dyno_result * result)
-{
+static void dyno_calculate_result(dyno_measure * measure0, dyno_measure * measure1, dyno_result * result) {
   /* effective power and lost power */
   int p_dyno, p_loss;
 
@@ -433,14 +404,12 @@ static void dyno_calculate_result(dyno_measure * measure0, dyno_measure * measur
 /*
  * Calculate results
  */
-static void dyno_calculate_results(dyno_result * results)
-{
+static void dyno_calculate_results(dyno_result * results) {
   int i;
   int nb = dyno_get_nb_results();
 
   /* for each measure, calculate result */
-  for (i=0; i<nb; i++)
-  {
+  for (i=0; i<nb; i++) {
     dyno_calculate_result(&measure_table.meas.measures[i], &measure_table.meas.measures[i+1], &results[i]);
   }
 }
@@ -448,8 +417,7 @@ static void dyno_calculate_results(dyno_result * results)
 /*
  * Get number of results
  */
-int dyno_get_nb_results()
-{
+int dyno_get_nb_results() {
   return (measure_table.nbr - 1);
 }
 
@@ -457,8 +425,7 @@ int dyno_get_nb_results()
  * Get dyno results
  */
 
-int dyno_get_results(dyno_result * results, UNUSED(int size))
-{
+int dyno_get_results(dyno_result * results, UNUSED(int size)) {
   if ((dyno_mass == 0) || (dyno_gear == 0))
     return DYNO_USAGE;
 
@@ -470,8 +437,7 @@ int dyno_get_results(dyno_result * results, UNUSED(int size))
 /*
  * Smooth results
  */
-int dyno_smooth_results(dyno_result * results, int size)
-{
+int dyno_smooth_results(dyno_result * results, int size) {
   dyno_result * rawresults;
   int i;
 
@@ -480,8 +446,7 @@ int dyno_smooth_results(dyno_result * results, int size)
     return DIAG_ERR_NOMEM;
   memcpy(rawresults, results, size * sizeof(dyno_result));
 
-  for (i=1; i<size-1; i++)
-  {
+  for (i=1; i<size-1; i++) {
     /* smooth using nearby values */
     results[i].power    = (rawresults[i-1].power + rawresults[i].power + rawresults[i+1].power) / 3;
     results[i].power_ch = POWER_CH(results[i].power);
@@ -497,15 +462,13 @@ int dyno_smooth_results(dyno_result * results, int size)
 /*
  * Save measures and results to a file
  */
-void dyno_save(char * filename, dyno_result * results, int size)
-{
+void dyno_save(char * filename, dyno_result * results, int size) {
   char buffer[MAXRBUF];
   int i;
 
   /* open file */
   FILE * fd = fopen (filename, "w");
-  if (fd == NULL)
-  {
+  if (fd == NULL) {
     printf("Failed opening %s for writing\n", filename);
     return;
   }
@@ -532,8 +495,7 @@ void dyno_save(char * filename, dyno_result * results, int size)
   sprintf(buffer, "RPM\tPower (W)\tPower (ch)\tTorque (N.m)\n");
   fwrite(buffer, strlen(buffer), sizeof(char), fd);
 
-  for (i=0; i<size; i++)
-  {
+  for (i=0; i<size; i++) {
     sprintf(buffer, "%d\t%d\t%d\t%d\n",
       results[i].rpm, results[i].power, results[i].power_ch, results[i].torque);
     fwrite(buffer, strlen(buffer), sizeof(char), fd);
@@ -544,8 +506,7 @@ void dyno_save(char * filename, dyno_result * results, int size)
 
 
   /* saving run measures */
-  if (measure_table.nbr > 0)
-  {
+  if (measure_table.nbr > 0) {
     printf("-> saving run measures...\n");
 
     sprintf(buffer, "Run measures\n");
@@ -554,8 +515,7 @@ void dyno_save(char * filename, dyno_result * results, int size)
     sprintf(buffer, "Time (ms)\tRPM\tSpeed (m/s)\tSpeed (km/h)\n");
     fwrite(buffer, strlen(buffer), sizeof(char), fd);
 
-    for (i=0; i<measure_table.nbr; i++)
-    {
+    for (i=0; i<measure_table.nbr; i++) {
       sprintf(buffer, "%d\t%d\t%7.3f\t%7.3f\n",
         measure_table.meas.measures[i].millis,
         measure_table.meas.measures[i].rpm,
@@ -586,8 +546,7 @@ void dyno_save(char * filename, dyno_result * results, int size)
 
 
   /* saving loss measures, if any */
-  if (loss_measure_table.nbr > 0)
-  {
+  if (loss_measure_table.nbr > 0) {
 
     printf("-> saving loss measures...\n");
 
@@ -597,8 +556,7 @@ void dyno_save(char * filename, dyno_result * results, int size)
     sprintf(buffer, "Time (ms)\tSpeed (m/s)\tSpeed (km/h)\n");
     fwrite(buffer, strlen(buffer), sizeof(char), fd);
 
-    for (i=0; i<loss_measure_table.nbr; i++)
-    {
+    for (i=0; i<loss_measure_table.nbr; i++) {
       sprintf(buffer, "%d\t%7.3f\t%7.3f\n",
         loss_measure_table.meas.loss_measures[i].millis,
         loss_measure_table.meas.loss_measures[i].speed/1000.0,

--- a/scantool/dyno.c
+++ b/scantool/dyno.c
@@ -60,7 +60,7 @@ struct dyno_measure_table measure_table;
  *****************************************************************************/
 
 /* Check table allocated size before addind a new element */
-static int dyno_check_allocated_table(struct dyno_measure_table * table, size_t elt_size) {
+static int dyno_check_allocated_table(struct dyno_measure_table *table, size_t elt_size) {
   if (table->meas.measures == NULL) {
     /* allocating the table */
     table->size = DYNO_DEFAULT_TABLE_SIZE;
@@ -69,7 +69,7 @@ static int dyno_check_allocated_table(struct dyno_measure_table * table, size_t 
 		return DIAG_ERR_NOMEM;
   } else if (table->nbr == table->size) {
     /* reallocating the table if maximum capacity is reached */
-    void * ptr;
+    void *ptr;
 
     /* new table size */
     table->size *= 2;
@@ -88,7 +88,7 @@ static int dyno_check_allocated_table(struct dyno_measure_table * table, size_t 
 }
 
 /* reset table content */
-static int dyno_table_reset(struct dyno_measure_table * table) {
+static int dyno_table_reset(struct dyno_measure_table *table) {
   if (table->meas.measures != NULL) {
     free(table->meas.measures);
     table->meas.measures = NULL;
@@ -201,8 +201,8 @@ double dyno_loss_f;
 /* get acceleration between 2 measures (m/s^2) */
 static double dyno_loss_a_inter(int i, int j) {
   double a;
-  dyno_loss_measure * measure0;
-  dyno_loss_measure * measure1;
+  dyno_loss_measure *measure0;
+  dyno_loss_measure *measure1;
 
   /* avoid bad use */
   if ((i < 0) || (i >= j) || (j > loss_measure_table.nbr))
@@ -243,8 +243,8 @@ static double dyno_loss_y(int i) {
 static int dyno_loss_calculate(void) {
   int i, nb;
   double sum;
-  dyno_loss_measure * measure0;
-  dyno_loss_measure * measure1;
+  dyno_loss_measure *measure0;
+  dyno_loss_measure *measure1;
 
   /* calculate d */
   nb = loss_measure_table.nbr - 1;
@@ -357,7 +357,7 @@ int dyno_get_nb_measures() {
 }
 
 /* Get all measures */
-int dyno_get_measures(dyno_measure * measures, int size) {
+int dyno_get_measures(dyno_measure *measures, int size) {
   /* copy measures */
   memcpy(measures, measure_table.meas.measures, MIN(size, measure_table.nbr) * sizeof(dyno_measure));
 
@@ -378,7 +378,7 @@ int dyno_get_measures(dyno_measure * measures, int size) {
 /*
  * Calculate power between 2 acceleration measures
  */
-static void dyno_calculate_result(dyno_measure * measure0, dyno_measure * measure1, dyno_result * result) {
+static void dyno_calculate_result(dyno_measure *measure0, dyno_measure *measure1, dyno_result *result) {
   /* effective power and lost power */
   int p_dyno, p_loss;
 
@@ -403,7 +403,7 @@ static void dyno_calculate_result(dyno_measure * measure0, dyno_measure * measur
 /*
  * Calculate results
  */
-static void dyno_calculate_results(dyno_result * results) {
+static void dyno_calculate_results(dyno_result *results) {
   int i;
   int nb = dyno_get_nb_results();
 
@@ -424,7 +424,7 @@ int dyno_get_nb_results() {
  * Get dyno results
  */
 
-int dyno_get_results(dyno_result * results, UNUSED(int size)) {
+int dyno_get_results(dyno_result *results, UNUSED(int size)) {
   if ((dyno_mass == 0) || (dyno_gear == 0))
     return DYNO_USAGE;
 
@@ -436,8 +436,8 @@ int dyno_get_results(dyno_result * results, UNUSED(int size)) {
 /*
  * Smooth results
  */
-int dyno_smooth_results(dyno_result * results, int size) {
-  dyno_result * rawresults;
+int dyno_smooth_results(dyno_result *results, int size) {
+  dyno_result *rawresults;
   int i;
 
   /* smooth results */
@@ -461,12 +461,12 @@ int dyno_smooth_results(dyno_result * results, int size) {
 /*
  * Save measures and results to a file
  */
-void dyno_save(char * filename, dyno_result * results, int size) {
+void dyno_save(char *filename, dyno_result *results, int size) {
   char buffer[MAXRBUF];
   int i;
 
   /* open file */
-  FILE * fd = fopen (filename, "w");
+  FILE *fd = fopen (filename, "w");
   if (fd == NULL) {
     printf("Failed opening %s for writing\n", filename);
     return;

--- a/scantool/dyno.c
+++ b/scantool/dyno.c
@@ -67,8 +67,7 @@ static int dyno_check_allocated_table(struct dyno_measure_table * table, size_t 
     table->nbr  = 0;
     if (diag_malloc(&table->meas.measures, table->size * elt_size))
 		return DIAG_ERR_NOMEM;
-  }
-  else if (table->nbr == table->size) {
+  } else if (table->nbr == table->size) {
     /* reallocating the table if maximum capacity is reached */
     void * ptr;
 

--- a/scantool/dyno.h
+++ b/scantool/dyno.h
@@ -99,21 +99,21 @@ int dyno_reset(void);
 int dyno_get_nb_measures(void);
 
 /* Get all measures */
-int dyno_get_measures(dyno_measure * measures, int size);
+int dyno_get_measures(dyno_measure *measures, int size);
 
 
 /* Get number of results */
 int dyno_get_nb_results(void);
 
 /* Get power and torque results */
-int dyno_get_results(dyno_result * results, int size);
+int dyno_get_results(dyno_result *results, int size);
 
 /* smooth results */
-int dyno_smooth_results(dyno_result * results, int size);
+int dyno_smooth_results(dyno_result *results, int size);
 
 
 /* save measures and results to a file */
-void dyno_save(char * filename, dyno_result * results, int size);
+void dyno_save(char *filename, dyno_result *results, int size);
 
 #if defined(__cplusplus)
 }

--- a/scantool/dyno.h
+++ b/scantool/dyno.h
@@ -36,22 +36,19 @@ extern "C" {
 #define DYNO_USAGE  -1  /* Bad usage */
 
 /* structure for loss measure tables */
-typedef struct dyno_loss_measure
-{
+typedef struct dyno_loss_measure {
   int millis; /* number of milliseconds */
 	int	speed;  /* m/s * 1000 */
 } dyno_loss_measure;
 
 /* structure for measure tables */
-typedef struct dyno_measure
-{
+typedef struct dyno_measure {
   int millis; /* number of milliseconds */
 	int	rpm;    /* rpm */
 } dyno_measure;
 
 /* structure for dyno results */
-typedef struct dyno_result
-{
+typedef struct dyno_result {
   int rpm; /* rev per minute */
   int power; /* power (W) */
   int power_ch; /* power (ch DYN) */

--- a/scantool/scantool.c
+++ b/scantool/scantool.c
@@ -122,8 +122,7 @@ const int _RQST_HANDLE_READINESS = RQST_HANDLE_READINESS; 	//Readiness tests
 
 
 struct diag_msg *
-find_ecu_msg(int byte, databyte_type val)
-{
+find_ecu_msg(int byte, databyte_type val) {
 	ecu_data_t *ep;
 	struct diag_msg *rxmsg = NULL;
 	unsigned int i;
@@ -161,8 +160,7 @@ find_ecu_msg(int byte, databyte_type val)
  * of data on certain vehicles
  */
 void
-j1979_data_rcv(void *handle, struct diag_msg *msg)
-{
+j1979_data_rcv(void *handle, struct diag_msg *msg) {
 	assert(msg != NULL);
 	uint8_t *data;
 	struct diag_msg *tmsg;
@@ -407,8 +405,7 @@ j1979_data_rcv(void *handle, struct diag_msg *msg)
  * just print the data
  */
 void
-j1979_watch_rcv(void *handle, struct diag_msg *msg)
-{
+j1979_watch_rcv(void *handle, struct diag_msg *msg) {
 	struct diag_msg *tmsg;
 	int i=0;
 
@@ -429,8 +426,7 @@ j1979_watch_rcv(void *handle, struct diag_msg *msg)
 
 
 void
-l2raw_data_rcv(UNUSED(void *handle), struct diag_msg *msg)
-{
+l2raw_data_rcv(UNUSED(void *handle), struct diag_msg *msg) {
 	/*
 	 * Layer 2 call back, just print the data, this is used if we
 	 * do a "read" and we haven't yet added a L3 protocol
@@ -444,8 +440,7 @@ l2raw_data_rcv(UNUSED(void *handle), struct diag_msg *msg)
  * to a mode 1 PID 0/0x20/0x40 request
  */
 int
-l2_check_pid_bits(uint8_t *data, int pid)
-{
+l2_check_pid_bits(uint8_t *data, int pid) {
 	int offset;
 	int bit;
 
@@ -469,10 +464,9 @@ l2_check_pid_bits(uint8_t *data, int pid)
 
 int
 l3_do_j1979_rqst(struct diag_l3_conn *d_conn, uint8_t mode, uint8_t p1, uint8_t p2,
-	uint8_t p3, uint8_t p4, uint8_t p5, uint8_t p6, void *handle)
-{
+	uint8_t p3, uint8_t p4, uint8_t p5, uint8_t p6, void *handle) {
 	assert(d_conn != NULL);
-	struct diag_msg msg={0};
+	struct diag_msg msg = {0};
 	uint8_t data[7];
 	int ihandle;
 	int rv;
@@ -603,9 +597,8 @@ l3_do_j1979_rqst(struct diag_l3_conn *d_conn, uint8_t mode, uint8_t p1, uint8_t 
  * Send some data to the ECU (L3)
  */
 int
-l3_do_send(struct diag_l3_conn *d_conn, void *data, size_t len, void *handle)
-{
-	struct diag_msg msg={0};
+l3_do_send(struct diag_l3_conn *d_conn, void *data, size_t len, void *handle) {
+	struct diag_msg msg = {0};
 	int rv;
 	if (len > 255)
 		return DIAG_ERR_GENERAL;
@@ -627,9 +620,8 @@ l3_do_send(struct diag_l3_conn *d_conn, void *data, size_t len, void *handle)
  * Same but L2 type
  */
 int
-l2_do_send(struct diag_l2_conn *d_conn, void *data, size_t len, void *handle)
-{
-	struct diag_msg msg={0};
+l2_do_send(struct diag_l2_conn *d_conn, void *data, size_t len, void *handle) {
+	struct diag_msg msg = {0};
 	int rv;
 	if (len > 255)
 		return DIAG_ERR_GENERAL;
@@ -667,8 +659,7 @@ l2_do_send(struct diag_l2_conn *d_conn, void *data, size_t len, void *handle)
  * Clear data that is relevant to an ECU
  */
 static int
-clear_data(void)
-{
+clear_data(void) {
 	ecu_count = 0;
 	memset(ecu_info, 0, sizeof(ecu_info));
 
@@ -685,8 +676,7 @@ clear_data(void)
   * returns L2 file descriptor
  */
 static struct diag_l2_conn * do_l2_common_start(int L1protocol, int L2protocol,
-	flag_type type, unsigned int bitrate, target_type target, source_type source )
-{
+	flag_type type, unsigned int bitrate, target_type target, source_type source ) {
 	int rv;
 	struct diag_l0_device *dl0d = global_dl0d;
 	struct diag_l2_conn *d_conn = NULL;
@@ -749,8 +739,7 @@ static struct diag_l2_conn * do_l2_common_start(int L1protocol, int L2protocol,
  * 9141 init
  */
 int
-do_l2_9141_start(int destaddr)
-{
+do_l2_9141_start(int destaddr) {
 	struct diag_l2_conn *d_conn;
 
 	d_conn = do_l2_common_start(DIAG_L1_ISO9141, DIAG_L2_PROT_ISO9141,
@@ -770,8 +759,7 @@ do_l2_9141_start(int destaddr)
  * 14120 init
  */
 int
-do_l2_14230_start(int init_type)
-{
+do_l2_14230_start(int init_type) {
 	struct diag_l2_conn *d_conn;
 	flag_type flags = 0;
 
@@ -800,8 +788,7 @@ do_l2_14230_start(int init_type)
  * J1850 init, J1850 interface type passed as l1_type
  */
 static int
-do_l2_j1850_start(int l1_type)
-{
+do_l2_j1850_start(int l1_type) {
 	flag_type flags = 0;
 	struct diag_l2_conn *d_conn;
 
@@ -829,8 +816,7 @@ do_l2_j1850_start(int l1_type)
  * It is used in "Interuptible" mode when doing "monitor" command
  */
 int
-do_j1979_getdata(int interruptible)
-{
+do_j1979_getdata(int interruptible) {
 	unsigned int i,j;
 	int rv;
 	struct diag_l3_conn *d_conn;
@@ -919,8 +905,7 @@ do_j1979_getdata(int interruptible)
  *
  * This is the basic work horse routine
  */
-void do_j1979_basics()
-{
+void do_j1979_basics() {
 	ecu_data_t *ep;
 	unsigned int i;
 	int o2monitoring = 0;
@@ -1001,8 +986,7 @@ void do_j1979_basics()
 }
 
 int
-print_single_dtc(databyte_type d0, databyte_type d1)
-{
+print_single_dtc(databyte_type d0, databyte_type d1) {
 	char buf[256];
 
 	uint8_t db[2];
@@ -1017,8 +1001,7 @@ print_single_dtc(databyte_type d0, databyte_type d1)
 }
 
 static void
-print_dtcs(uint8_t *data, uint8_t len)
-{
+print_dtcs(uint8_t *data, uint8_t len) {
 	/* Print the DTCs just received */
 	int i, j;
 
@@ -1033,8 +1016,7 @@ print_dtcs(uint8_t *data, uint8_t len)
  * Get test results for constantly monitored systems
  */
 void
-do_j1979_cms()
-{
+do_j1979_cms() {
 	int rv;
 	unsigned int i;
 	struct diag_l3_conn *d_conn;
@@ -1073,8 +1055,7 @@ do_j1979_cms()
  * Get test results for non-constantly monitored systems
  */
 void
-do_j1979_ncms(int printall)
-{
+do_j1979_ncms(int printall) {
 	int rv;
 	struct diag_l3_conn *d_conn;
 	unsigned int i, j;
@@ -1130,8 +1111,7 @@ do_j1979_ncms(int printall)
  * the ECU)
  */
 void
-do_j1979_getmodeinfo(uint8_t mode, int response_offset)
-{
+do_j1979_getmodeinfo(uint8_t mode, int response_offset) {
 	int rv;
 	struct diag_l3_conn *d_conn;
 	int pid;
@@ -1222,8 +1202,7 @@ do_j1979_getmodeinfo(uint8_t mode, int response_offset)
  * what the ECU supports
  */
 void
-do_j1979_getpids()
-{
+do_j1979_getpids() {
 	ecu_data_t *ep;
 	unsigned int i, j;
 
@@ -1259,8 +1238,7 @@ do_j1979_getpids()
  * Do the O2 tests for this O2 sensor
  */
 void
-do_j1979_O2tests()
-{
+do_j1979_O2tests() {
 	int i;
 
 	if (merged_mode5_info[0] == 0) {
@@ -1282,8 +1260,7 @@ do_j1979_O2tests()
  * O2sensor is the bit number
  */
 void
-do_j1979_getO2tests(int O2sensor)
-{
+do_j1979_getO2tests(int O2sensor) {
 
 	int rv;
 	struct diag_l3_conn *d_conn;
@@ -1314,8 +1291,7 @@ do_j1979_getO2tests(int O2sensor)
  * and test, and wait for those tests to complete
  */
 int
-do_j1979_getdtcs()
-{
+do_j1979_getdtcs() {
 	int rv;
 	struct diag_l3_conn *d_conn;
 	ecu_data_t *ep;
@@ -1396,8 +1372,7 @@ do_j1979_getdtcs()
  * Get supported DTCS
  */
 int
-do_j1979_getO2sensors()
-{
+do_j1979_getO2sensors() {
 	int rv;
 	struct diag_l3_conn *d_conn;
 	unsigned int i, j;
@@ -1436,8 +1411,7 @@ do_j1979_getO2sensors()
 }
 
 int
-diag_cleardtc(void)
-{
+diag_cleardtc(void) {
 	/* Clear DTCs */
 	struct diag_l3_conn *d_conn;
 	int rv;
@@ -1480,8 +1454,7 @@ const struct protocol protocols[] = {
  * This will set global_l3_conn. Ret 0 if ok
  */
 int
-ecu_connect(void)
-{
+ecu_connect(void) {
 	int connected=0;
 	int rv = DIAG_ERR_GENERAL;
 	const struct protocol *p;
@@ -1539,8 +1512,7 @@ ecu_connect(void)
  * Initialise
  */
 static int
-do_init(void)
-{
+do_init(void) {
 	clear_data();
 
 	return 0;
@@ -1549,8 +1521,7 @@ do_init(void)
 /*
  * Explain command line usage
  */
-static void do_usage (void)
-{
+static void do_usage (void) {
 	fprintf( stderr, "FreeDiag ScanTool:\n\n" ) ;
 	fprintf( stderr, "  Usage -\n" ) ;
 	fprintf( stderr, "	scantool [-h][-a|-c][-f <file]\n\n" ) ;
@@ -1568,8 +1539,7 @@ static void do_usage (void)
 
 
 static void format_o2(char *buf, int maxlen, UNUSED(int english),
-	const struct pid *p, response_t *data, int n)
-{
+	const struct pid *p, response_t *data, int n) {
 		double v = DATA_SCALED(p, DATA_1(p, n, data));
 		int t = DATA_1(p, n + 1, data);
 
@@ -1582,8 +1552,7 @@ static void format_o2(char *buf, int maxlen, UNUSED(int english),
 
 static void
 format_aux(char *buf, int maxlen, UNUSED(int english), const struct pid *p,
-	response_t *data, int n)
-{
+	response_t *data, int n) {
 		snprintf(buf, maxlen, (DATA_RAW(p, n, data) & 1) ? "PTO Active" : "----");
 }
 
@@ -1591,8 +1560,7 @@ format_aux(char *buf, int maxlen, UNUSED(int english), const struct pid *p,
 
 static void
 format_fuel(char *buf, int maxlen, UNUSED(int english), const struct pid *p,
-	response_t *data, int n)
-{
+	response_t *data, int n) {
 		int s = DATA_1(p, n, data);
 
 		switch (s) {
@@ -1621,8 +1589,7 @@ format_fuel(char *buf, int maxlen, UNUSED(int english), const struct pid *p,
 
 
 static void
-format_data(char *buf, int maxlen, int english, const struct pid *p, response_t *data, int n)
-{
+format_data(char *buf, int maxlen, int english, const struct pid *p, response_t *data, int n) {
 		double v;
 
 		v = DATA_SCALED(p, DATA_RAW(p, n, data));
@@ -1717,8 +1684,7 @@ static const struct pid pids[] = {
 };
 
 
-const struct pid *get_pid ( unsigned int i )
-{
+const struct pid *get_pid ( unsigned int i ) {
 	if ( i >= ARRAY_SIZE(pids) )
 		return NULL ;
 
@@ -1731,8 +1697,7 @@ const struct pid *get_pid ( unsigned int i )
  */
 
 int
-main(int argc, char **argv)
-{
+main(int argc, char **argv) {
 	int user_interface = 1 ;
 	int i ;
 	const char *startfile=NULL;	/* optional commands to run at startup */

--- a/scantool/scantool.c
+++ b/scantool/scantool.c
@@ -675,7 +675,7 @@ clear_data(void) {
  * - opens a Layer 2 device for the specified Layer 1 protocol
   * returns L2 file descriptor
  */
-static struct diag_l2_conn * do_l2_common_start(int L1protocol, int L2protocol,
+static struct diag_l2_conn *do_l2_common_start(int L1protocol, int L2protocol,
 	flag_type type, unsigned int bitrate, target_type target, source_type source ) {
 	int rv;
 	struct diag_l0_device *dl0d = global_dl0d;

--- a/scantool/scantool.h
+++ b/scantool/scantool.h
@@ -41,8 +41,7 @@ extern "C" {
 
 
 /* Structure to hold responses */
-typedef struct response
-{
+typedef struct response {
 	uint8_t	type;
 	uint8_t	len;
 	uint8_t	data[7];
@@ -58,8 +57,7 @@ typedef struct response
  * - one request can result in more than one ECU responding, and so
  * the data is stored in this
  */
-typedef struct ecu_data
-{
+typedef struct ecu_data {
 	uint8_t 	valid;		/* Valid flag */
 	uint8_t	ecu_addr;	/* Address */
 
@@ -163,8 +161,7 @@ struct pid ;
 /* format <numbytes> bytes of data into buf, up to <maxlen> chars. */
 typedef void (formatter)(char *buf, int maxlen, int units, const struct pid *, response_t *, int numbytes);
 
-struct pid
-{
+struct pid {
 	int pidID ;
 	const char *desc ;
 	formatter *cust_snprintf ;

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -118,8 +118,7 @@ static int cmd_850_freeze(int argc, char **argv);
 static int cmd_850_scan_all(int argc, UNUSED(char **argv));
 static int cmd_850_test(int argc, char **argv);
 
-const struct cmd_tbl_entry v850_cmd_table[] =
-{
+const struct cmd_tbl_entry v850_cmd_table[] = {
 	{ "help", "help [command]", "Gives help for a command",
 		cmd_850_help, 0, NULL},
 	{ "?", "? [command]", "Gives help for a command",
@@ -167,8 +166,7 @@ const struct cmd_tbl_entry v850_cmd_table[] =
 };
 
 static int
-cmd_850_help(int argc, char **argv)
-{
+cmd_850_help(int argc, char **argv) {
 	return help_common(argc, argv, v850_cmd_table);
 }
 
@@ -177,8 +175,7 @@ cmd_850_help(int argc, char **argv)
  * Returns a static buffer that will be reused on the next call.
  */
 static char *
-capitalize(const char *in)
-{
+capitalize(const char *in) {
 	static char buf[80];
 
 	strncpy(buf, in, sizeof(buf));
@@ -193,8 +190,7 @@ capitalize(const char *in)
  * Look up an ECU by name.
  */
 static struct ecu_info *
-ecu_info_by_name(const char *name)
-{
+ecu_info_by_name(const char *name) {
 	struct ecu_info *ecu;
 
 	for (ecu = ecu_list; ecu->name != NULL; ecu++) {
@@ -209,8 +205,7 @@ ecu_info_by_name(const char *name)
  * Get an ECU's address by name.
  */
 static int
-ecu_addr_by_name(const char *name)
-{
+ecu_addr_by_name(const char *name) {
 	struct ecu_info *ecu;
 	unsigned long int i;
 	char *p;
@@ -236,8 +231,7 @@ ecu_addr_by_name(const char *name)
  * Get an ECU's description by address.
  */
 static char *
-ecu_desc_by_addr(uint8_t addr)
-{
+ecu_desc_by_addr(uint8_t addr) {
 	struct ecu_info *ecu;
 	static char buf[7];
 
@@ -254,8 +248,7 @@ ecu_desc_by_addr(uint8_t addr)
  * Get the description of the currently connected ECU.
  */
 static char *
-current_ecu_desc(void)
-{
+current_ecu_desc(void) {
 	int addr;
 
 	if (global_state < STATE_CONNECTED)
@@ -275,8 +268,7 @@ current_ecu_desc(void)
  * Returns a static buffer that will be reused on the next call.
  */
 static char *
-dtc_printable_by_raw(uint8_t addr, uint8_t raw, char **desc)
-{
+dtc_printable_by_raw(uint8_t addr, uint8_t raw, char **desc) {
 	static char printable[7+1];
 	static char *empty="";
 	struct ecu_info *ecu_entry;
@@ -312,8 +304,7 @@ dtc_printable_by_raw(uint8_t addr, uint8_t raw, char **desc)
  * Get the DTC prefix for the currently connected ECU.
  */
 static char *
-current_dtc_prefix(void)
-{
+current_dtc_prefix(void) {
 	struct ecu_info *ecu;
 
 	if (global_state < STATE_CONNECTED)
@@ -332,8 +323,7 @@ current_dtc_prefix(void)
  * failure.
  */
 static uint16_t
-dtc_raw_by_printable(char *printable)
-{
+dtc_raw_by_printable(char *printable) {
 	char prefix[8];
 	uint16_t suffix;
 	char *p, *q, *r;
@@ -373,8 +363,7 @@ dtc_raw_by_printable(char *printable)
  * present in the vehicle.
  */
 static void
-print_ecu_list(void)
-{
+print_ecu_list(void) {
 	struct ecu_info *ecu;
 
 	for (ecu = ecu_list; ecu->name != NULL; ecu++) {
@@ -394,8 +383,7 @@ enum connection_status {
  * Indicates whether we're currently connected.
  */
 static enum connection_status
-get_connection_status(void)
-{
+get_connection_status(void) {
 	if (global_state < STATE_CONNECTED) {
 		return NOT_CONNECTED;
 	} else if (global_l2_conn->l2proto->diag_l2_protocol == DIAG_L2_PROT_D2) {
@@ -412,8 +400,7 @@ get_connection_status(void)
  * minimum and maximum. If not, print a message and return false.
  */
 static bool
-valid_arg_count(int min, int argc, int max)
-{
+valid_arg_count(int min, int argc, int max) {
 	if(argc < min) {
                 printf("Too few arguments\n");
                 return false;
@@ -432,8 +419,7 @@ valid_arg_count(int min, int argc, int max)
  * for this command. If not, print a message and return false.
  */
 static bool
-valid_connection_status(unsigned int want)
-{
+valid_connection_status(unsigned int want) {
 	if (want == CONNECTED_EITHER) {
 		if (get_connection_status()==CONNECTED_D2 || get_connection_status()==CONNECTED_KWP71)
 			return true;
@@ -471,8 +457,7 @@ valid_connection_status(unsigned int want)
  * response time.
  */
 static void
-adaptive_timing_workaround(void)
-{
+adaptive_timing_workaround(void) {
 	int i;
 
 	for (i=0;i<3;i++) {
@@ -485,8 +470,7 @@ adaptive_timing_workaround(void)
  * Callback to store the ID block upon establishing a KWP71 connection
  */
 static void
-ecu_id_callback(void *handle, struct diag_msg *in)
-{
+ecu_id_callback(void *handle, struct diag_msg *in) {
 	struct diag_msg **out = (struct diag_msg **)handle;
 	*out = diag_dupmsg(in);
 }
@@ -495,8 +479,7 @@ ecu_id_callback(void *handle, struct diag_msg *in)
  * Connect to an ECU by name or address.
  */
 static int
-cmd_850_connect(int argc, char **argv)
-{
+cmd_850_connect(int argc, char **argv) {
 	int addr;
 	int rv;
 	struct diag_l0_device *dl0d;
@@ -606,8 +589,7 @@ cmd_850_connect(int argc, char **argv)
  * Close the current connection.
  */
 static int
-cmd_850_disconnect(int argc, UNUSED(char **argv))
-{
+cmd_850_disconnect(int argc, UNUSED(char **argv)) {
 	char *desc;
 
 	if (!valid_arg_count(1, argc, 1))
@@ -633,8 +615,7 @@ cmd_850_disconnect(int argc, UNUSED(char **argv))
  * Send a raw command and print the response.
  */
 static int
-cmd_850_sendreq(int argc, char **argv)
-{
+cmd_850_sendreq(int argc, char **argv) {
 	uint8_t data[MAXRBUF] = {0};
 	unsigned int len;
 	unsigned int i;
@@ -667,8 +648,7 @@ cmd_850_sendreq(int argc, char **argv)
  * Verify communication with the ECU.
  */
 static int
-cmd_850_ping(int argc, UNUSED(char **argv))
-{
+cmd_850_ping(int argc, UNUSED(char **argv)) {
 	int rv;
 
 	if (!valid_arg_count(1, argc, 1))
@@ -697,8 +677,7 @@ cmd_850_ping(int argc, UNUSED(char **argv))
  * scaled value.
  */
 static void
-interpret_value(enum namespace ns, uint16_t addr, UNUSED(int len), uint8_t *buf)
-{
+interpret_value(enum namespace ns, uint16_t addr, UNUSED(int len), uint8_t *buf) {
 	if (ns==NS_LIVEDATA && addr==0x0200) {
 		printf("Engine Coolant Temperature: %dC (%dF)\n", buf[1]-80, (buf[1]-80)*9/5+32);
 	} else if (ns==NS_LIVEDATA && addr==0x0300) {
@@ -716,8 +695,7 @@ interpret_value(enum namespace ns, uint16_t addr, UNUSED(int len), uint8_t *buf)
  * Try to interpret all the live data values in the buffer.
  */
 static void
-interpret_block(enum namespace ns, uint16_t addr, int len, uint8_t *buf)
-{
+interpret_block(enum namespace ns, uint16_t addr, int len, uint8_t *buf) {
 	int i;
 
 	if (ns != NS_MEMORY)
@@ -733,8 +711,7 @@ interpret_block(enum namespace ns, uint16_t addr, int len, uint8_t *buf)
  * values.
  */
 static int
-print_hexdump_line(FILE *f, uint16_t addr, int addr_chars, uint8_t *buf, uint16_t len)
-{
+print_hexdump_line(FILE *f, uint16_t addr, int addr_chars, uint8_t *buf, uint16_t len) {
 	if (fprintf(f, "%0*X:", addr_chars, addr) < 0)
 		return 1;
 	while (len--) {
@@ -756,8 +733,7 @@ struct read_or_peek_item {
  * Parse an address argument on a peek command line.
  */
 static int
-parse_peek_arg(char *arg, struct read_or_peek_item *item)
-{
+parse_peek_arg(char *arg, struct read_or_peek_item *item) {
 	char *p, *q;
 
 	item->ns = NS_MEMORY;
@@ -785,8 +761,7 @@ parse_peek_arg(char *arg, struct read_or_peek_item *item)
  * Parse an identifier argument on a read command line.
  */
 static int
-parse_read_arg(char *arg, struct read_or_peek_item *item)
-{
+parse_read_arg(char *arg, struct read_or_peek_item *item) {
 	char *p;
 
 	if(arg[0] == '*') {
@@ -810,8 +785,7 @@ parse_read_arg(char *arg, struct read_or_peek_item *item)
  * Parse an identifier argument on an adc command line.
  */
 static int
-parse_adc_arg(char *arg, struct read_or_peek_item *item)
-{
+parse_adc_arg(char *arg, struct read_or_peek_item *item) {
 	char *p;
 
 	item->ns = NS_ADC;
@@ -827,8 +801,7 @@ parse_adc_arg(char *arg, struct read_or_peek_item *item)
  * Parse an identifier argument on a readnv command line.
  */
 static int
-parse_readnv_arg(char *arg, struct read_or_peek_item *item)
-{
+parse_readnv_arg(char *arg, struct read_or_peek_item *item) {
 	char *p;
 
 	item->ns = NS_NV;
@@ -844,8 +817,7 @@ parse_readnv_arg(char *arg, struct read_or_peek_item *item)
  * Parse an identifier argument on a freeze command line.
  */
 static int
-parse_freeze_arg(char *arg, struct read_or_peek_item *item)
-{
+parse_freeze_arg(char *arg, struct read_or_peek_item *item) {
 	char *p;
 
 	item->ns = NS_FREEZE;
@@ -879,8 +851,7 @@ parse_freeze_arg(char *arg, struct read_or_peek_item *item)
  * Execute a read, peek or readnv command.
  */
 static int
-read_family(int argc, char **argv, enum namespace ns)
-{
+read_family(int argc, char **argv, enum namespace ns) {
 	int count;
 	int i;
 	bool continuous;
@@ -1004,8 +975,7 @@ done:
  * the requested addresses until interrupted.
  */
 static int
-cmd_850_peek(int argc, char **argv)
-{
+cmd_850_peek(int argc, char **argv) {
 	return read_family(argc, argv, NS_MEMORY);
 }
 
@@ -1021,8 +991,7 @@ cmd_850_peek(int argc, char **argv)
  * the requested addresses until interrupted.
  */
 static int
-cmd_850_read(int argc, char **argv)
-{
+cmd_850_read(int argc, char **argv) {
 	if(!valid_connection_status(CONNECTED_D2))
 		return CMD_OK;
 
@@ -1038,8 +1007,7 @@ cmd_850_read(int argc, char **argv)
  * the requested readings until interrupted.
  */
 static int
-cmd_850_adc(int argc, char **argv)
-{
+cmd_850_adc(int argc, char **argv) {
 	if(!valid_connection_status(CONNECTED_KWP71))
 		return CMD_OK;
 
@@ -1053,8 +1021,7 @@ cmd_850_adc(int argc, char **argv)
  * Takes a list of one-byte identifier values.
  */
 static int
-cmd_850_readnv(int argc, char **argv)
-{
+cmd_850_readnv(int argc, char **argv) {
 	if(!valid_connection_status(CONNECTED_D2))
 		return CMD_OK;
 
@@ -1065,8 +1032,7 @@ cmd_850_readnv(int argc, char **argv)
  * Read and display freeze frames for all stored DTCs.
  */
 static int
-cmd_850_freeze_all(void)
-{
+cmd_850_freeze_all(void) {
 	uint8_t dtcs[12];
 	int count;
 	char *argbuf;
@@ -1119,8 +1085,7 @@ cmd_850_freeze_all(void)
  * EFI-xxx, AT-xxx, etc designation.
  */
 static int
-cmd_850_freeze(int argc, char **argv)
-{
+cmd_850_freeze(int argc, char **argv) {
 	if(!valid_connection_status(CONNECTED_D2))
 		return CMD_OK;
 
@@ -1135,8 +1100,7 @@ cmd_850_freeze(int argc, char **argv)
  * Query the ECU for identification and print the result.
  */
 static int
-cmd_850_id_d2(void)
-{
+cmd_850_id_d2(void) {
 	uint8_t buf[15];
 	int rv;
 	int i;
@@ -1187,8 +1151,7 @@ cmd_850_id_d2(void)
  * Print the ECU identification we received upon initial connection.
  */
 static int
-cmd_850_id_kwp71(void)
-{
+cmd_850_id_kwp71(void) {
 	int i;
 	struct diag_msg *msg;
 
@@ -1246,8 +1209,7 @@ cmd_850_id_kwp71(void)
  * Display ECU identification.
  */
 static int
-cmd_850_id(int argc, UNUSED(char **argv))
-{
+cmd_850_id(int argc, UNUSED(char **argv)) {
 	if (!valid_arg_count(1, argc, 1))
 		return CMD_USAGE;
 
@@ -1274,8 +1236,7 @@ cmd_850_id(int argc, UNUSED(char **argv))
  * when a read attempt fails.
  */
 static int
-cmd_850_dumpram(int argc, char **argv)
-{
+cmd_850_dumpram(int argc, char **argv) {
 	uint16_t addr;
 	FILE *f;
 	bool happy;
@@ -1344,8 +1305,7 @@ cmd_850_dumpram(int argc, char **argv)
  * Display list of stored DTCs.
  */
 static int
-cmd_850_dtc(int argc, UNUSED(char **argv))
-{
+cmd_850_dtc(int argc, UNUSED(char **argv)) {
 	uint8_t buf[12];
 	int rv;
 	int i;
@@ -1390,8 +1350,7 @@ cmd_850_dtc(int argc, UNUSED(char **argv))
  * Clear stored DTCs.
  */
 static int
-cmd_850_cleardtc(int argc, UNUSED(char **argv))
-{
+cmd_850_cleardtc(int argc, UNUSED(char **argv)) {
 	char *input;
 	int rv;
 
@@ -1450,8 +1409,7 @@ done:
  * same car.
  */
 static int
-cmd_850_scan_all(int argc, UNUSED(char **argv))
-{
+cmd_850_scan_all(int argc, UNUSED(char **argv)) {
 	struct ecu_info *ecu;
 	char *argvout[2];
 	char buf[4];

--- a/scantool/scantool_aif.c
+++ b/scantool/scantool_aif.c
@@ -121,13 +121,11 @@ static void aif_monitor (UNUSED(void *data)) {
 
 	if (rv == DIAG_ERR_TIMEOUT) {
 	/* Didn't get a response, this is valid if there are no DTCs */
-	}
-	else if (rv != 0) {
+	} else if (rv != 0) {
 		fprintf(stderr, "Failed to get test results for"
 		" continuously monitored systems\n") ;
 		BadToApp() ;
-	}
-	else {
+	} else {
 		/* Currently monitored DTCs: */
 
 		for (i = 0 ; i < ecu_count ; i++) {
@@ -249,8 +247,7 @@ static void aif_scan (UNUSED(void *data)) {
 		do_j1979_ncms  (0) ; /* And non-continuously monitored tests   */
 
 		OkToApp() ;
-	}
-	else {
+	} else {
 		fprintf(stderr, "Connection to ECU failed\n") ;
 		fprintf(stderr, "Please check :\n") ;
 		fprintf(stderr, "\tAdapter is connected to PC\n") ;

--- a/scantool/scantool_aif.c
+++ b/scantool/scantool_aif.c
@@ -46,8 +46,7 @@
 static void do_aif_command (void) ;
 static int debugging = 0 ;
 
-static void toApp (char command)
-{
+static void toApp (char command) {
 	putc(command, stdout) ;
 }
 
@@ -69,10 +68,8 @@ static void aif_vw(void *data) { (void) data; BadToApp() ; }
 static void aif_dyno(void *data) { (void) data; BadToApp() ; }
 
 
-static void aif_monitor (UNUSED(void *data))
-{
-	if (global_state < STATE_CONNECTED)
-	{
+static void aif_monitor (UNUSED(void *data)) {
+	if (global_state < STATE_CONNECTED) {
 		fprintf(stderr, "scantool: Can't monitor - car is not yet connected.\n");
 		BadToApp() ;
 		return ;
@@ -84,8 +81,7 @@ static void aif_monitor (UNUSED(void *data))
 	* whenever it requests it.
 	*/
 
-	while (1)
-	{
+	while (1) {
 		unsigned int i ;
 		int rv = do_j1979_getdata(1) ;
 		struct diag_l3_conn *d_conn ;
@@ -93,21 +89,17 @@ static void aif_monitor (UNUSED(void *data))
 
 		/* New request arrived. */
 
-		if (rv)
-		{
+		if (rv) {
 			unsigned int j ;
 
-			for (j = 0 ; get_pid(j) != NULL ; j++)
-			{
+			for (j = 0 ; get_pid(j) != NULL ; j++) {
 				const struct pid *p = get_pid(j) ;
 				ecu_data_t   *ep ;
 				char buf[24] ;
 
-				for (i = 0, ep = ecu_info ; i < ecu_count ; i++, ep++)
-				{
+				for (i = 0, ep = ecu_info ; i < ecu_count ; i++, ep++) {
 					if (DATA_VALID(p, ep->mode1_data) ||
-					DATA_VALID(p, ep->mode2_data))
-					{
+					DATA_VALID(p, ep->mode2_data)) {
 						if (DATA_VALID(p, ep->mode1_data))
 							p->cust_snprintf(buf, sizeof(buf), global_cfg.units, p, ep->mode1_data, 2);
 
@@ -127,8 +119,7 @@ static void aif_monitor (UNUSED(void *data))
 	rv = l3_do_j1979_rqst(d_conn, 0x07, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, (void *)&_RQST_HANDLE_NORMAL) ;
 
-	if (rv == DIAG_ERR_TIMEOUT)
-	{
+	if (rv == DIAG_ERR_TIMEOUT) {
 	/* Didn't get a response, this is valid if there are no DTCs */
 	}
 	else if (rv != 0) {
@@ -136,16 +127,14 @@ static void aif_monitor (UNUSED(void *data))
 		" continuously monitored systems\n") ;
 		BadToApp() ;
 	}
-	else
-	{
+	else {
 		/* Currently monitored DTCs: */
 
 		for (i = 0 ; i < ecu_count ; i++) {
 			LL_FOREACH(ecu_info[i].rxmsg, msg) {
 				int i, j ;
 
-				for (i = 0, j = 1 ; i < 3 ; i++, j += 2)
-				{
+				for (i = 0, j = 1 ; i < 3 ; i++, j += 2) {
 					char buf[256];
 					uint8_t db[2];
 
@@ -170,35 +159,30 @@ static void aif_monitor (UNUSED(void *data))
 }
 
 
-static void aif_set (void *data)
-{
+static void aif_set (void *data) {
 	int sub_command = ((unsigned char *) data)[0] ;
 
 	switch (sub_command) {
-		case FREEDIAG_AIF_SET_UNITS :
-		{
+		case FREEDIAG_AIF_SET_UNITS : {
 			int units = ((unsigned char *) data)[1] ;
 
 			if (debugging)
 				fprintf(stderr, "Setting units to %d\n", units) ;
 
-			switch (units)
-			{
+			switch (units) {
 				case FREEDIAG_AIF_SET_UNITS_US     : global_cfg.units = 1 ; break ;
 				case FREEDIAG_AIF_SET_UNITS_METRIC : global_cfg.units = 0 ; break ;
 				default        					: BadToApp() ; return ;
 			}
 			break ;
 		}
-		case FREEDIAG_AIF_SET_PORT :
-		{
+		case FREEDIAG_AIF_SET_PORT : {
 			int port = ((unsigned char *) data)[1] ;
 
 			if (debugging)
 				fprintf(stderr, "Setting port to %d\n", port) ;
 
-			if (port < 0 || port > 9)
-			{
+			if (port < 0 || port > 9) {
 				BadToApp() ;
 				return ;
 			}
@@ -218,14 +202,12 @@ static void aif_set (void *data)
 }
 
 
-static void aif_noop (UNUSED(void *data))
-{
+static void aif_noop (UNUSED(void *data)) {
 	OkToApp() ;
 }
 
 
-static void aif_exit (UNUSED(void *data))
-{
+static void aif_exit (UNUSED(void *data)) {
 	OkToApp() ;
 	fprintf(stderr, "scantool: Exiting.\n") ;
 	set_close();
@@ -233,16 +215,13 @@ static void aif_exit (UNUSED(void *data))
 }
 
 
-static void aif_disconnect (UNUSED(void *data))
-{
-	if (global_state < STATE_CONNECTED)
-	{
+static void aif_disconnect (UNUSED(void *data)) {
+	if (global_state < STATE_CONNECTED) {
 		OkToApp() ;
 		return ;
 	}
 
-	if (global_state >= STATE_L3ADDED)
-	{
+	if (global_state >= STATE_L3ADDED) {
 		/* Close L3 protocol */
 		diag_l3_stop(global_l3_conn);
 	}
@@ -258,24 +237,20 @@ static void aif_disconnect (UNUSED(void *data))
 
 
 
-static void aif_scan (UNUSED(void *data))
-{
-	if (global_state >= STATE_CONNECTED)
-	{
+static void aif_scan (UNUSED(void *data)) {
+	if (global_state >= STATE_CONNECTED) {
 		OkToApp() ;
 		return ;
 	}
 
-	if (ecu_connect() == 0)
-	{
+	if (ecu_connect() == 0) {
 		do_j1979_basics () ; /* Ask basic info from ECU */
 		do_j1979_cms	() ; /* Get test results for monitored systems */
 		do_j1979_ncms  (0) ; /* And non-continuously monitored tests   */
 
 		OkToApp() ;
 	}
-	else
-	{
+	else {
 		fprintf(stderr, "Connection to ECU failed\n") ;
 		fprintf(stderr, "Please check :\n") ;
 		fprintf(stderr, "\tAdapter is connected to PC\n") ;
@@ -288,8 +263,7 @@ static void aif_scan (UNUSED(void *data))
 }
 
 
-static void aif_debug (void *data)
-{
+static void aif_debug (void *data) {
 	debugging = ((char *) data)[0] ;
 
 	OkToApp() ;
@@ -301,8 +275,7 @@ static void aif_debug (void *data)
 
 typedef void (*aif_func) (void *) ;
 
-struct AIFcommand
-{
+struct AIFcommand {
 	const int	   code   ;
 	const int	   length ;
 	const char	 *name   ;
@@ -310,8 +283,7 @@ struct AIFcommand
 } ;
 
 
-const struct AIFcommand aif_commands[] =
-{
+const struct AIFcommand aif_commands[] = {
 	{ FREEDIAG_AIF_NO_OP	, 0, "Do Nothing"			, aif_noop	  },
 	{ FREEDIAG_AIF_EXIT	 , 0, "Exit ScanTool"		 , aif_exit	  },
 	{ FREEDIAG_AIF_MONITOR  , 0, "Monitor"			   , aif_monitor   },
@@ -330,36 +302,31 @@ const struct AIFcommand aif_commands[] =
 } ;
 
 
-static void do_aif_command (void)
-{
+static void do_aif_command (void) {
 	char data_buffer[FREEDIAG_AIF_INPUT_MAX] ;
 	int i, j ;
 
 	const struct AIFcommand *command=NULL ;
 	int cmd = fgetc(stdin) ;
 
-	if (cmd == -1)
-	{
+	if (cmd == -1) {
 		fprintf (stderr,
 		"scantool: Unexpected EOF from Application Interface\n") ;
 		BadToApp() ;
 		exit (1) ;
 	}
 
-	for (i = 0 ; aif_commands[i] . name != NULL ; i++)
-	{
+	for (i = 0 ; aif_commands[i] . name != NULL ; i++) {
 		command = & (aif_commands[i]) ;
 
-		if (command->code == cmd)
-		{
+		if (command->code == cmd) {
 			if (debugging)
 			fprintf(stderr, "CMD: %d %s\n", cmd, command->name) ;
 
 			break ;
 		}
 	}
-	if (command->name == NULL)
-	{
+	if (command->name == NULL) {
 		fprintf(stderr,
 		"scantool: Application sent AIF an illegal command '%d'\n",
 		cmd) ;
@@ -378,8 +345,7 @@ static void do_aif_command (void)
 }
 
 
-void enter_aif (const char *name)
-{
+void enter_aif (const char *name) {
 	fprintf(stderr, "%s AIF: version %s\n", name, PACKAGE_VERSION) ;
 	set_init() ;
 

--- a/scantool/scantool_cli.c
+++ b/scantool/scantool_cli.c
@@ -799,7 +799,7 @@ rc_file(void) {
 
 
 #ifdef USE_INIFILE
-	char * inihomeinit;
+	char *inihomeinit;
 	if (diag_malloc(&inihomeinit, strlen(progname) + strlen(".ini") + 1)) {
 		diag_iseterr(DIAG_ERR_NOMEM);
 		return CMD_OK;

--- a/scantool/scantool_cli.c
+++ b/scantool/scantool_cli.c
@@ -86,8 +86,7 @@ static int cmd_source(int argc, char **argv);
 const struct cmd_tbl_entry *root_cmd_table;	/* point to current root table */
 
 /* this table is appended to the "extra" cmdtable to construct the whole root cmd table */
-static const struct cmd_tbl_entry basic_cmd_table[]=
-{
+static const struct cmd_tbl_entry basic_cmd_table[] = {
 	{ "log", "log <filename>", "Log monitor data to <filename>",
 		cmd_log, FLAG_FILE_ARG, NULL},
 	{ "stoplog", "stoplog", "Stop logging", cmd_stoplog, 0, NULL},
@@ -144,8 +143,7 @@ static const struct cmd_tbl_entry *completion_cmd_level;
 #define INPUT_MAX 1024
 
 char *
-basic_get_input(const char *prompt, FILE *instream)
-{
+basic_get_input(const char *prompt, FILE *instream) {
 	char *input;
 	bool do_prompt;
 
@@ -180,8 +178,7 @@ basic_get_input(const char *prompt, FILE *instream)
 
 /* Caller must free returned buffer */
 static char *
-get_input(const char *prompt)
-{
+get_input(const char *prompt) {
 	char *input;
 	/* XXX Does readline change the prompt? */
 	char localprompt[128];
@@ -194,8 +191,7 @@ get_input(const char *prompt)
 }
 
 char *
-command_generator(const char *text, int state)
-{
+command_generator(const char *text, int state) {
 	static int list_index, length;
 	const struct cmd_tbl_entry *cmd_entry;
 
@@ -222,8 +218,7 @@ command_generator(const char *text, int state)
 }
 
 char **
-scantool_completion(const char *text, int start, UNUSED(int end))
-{
+scantool_completion(const char *text, int start, UNUSED(int end)) {
 	char **matches;
 
 	//start == 0 is when the command line is either empty or contains only whitespaces
@@ -300,8 +295,7 @@ scantool_completion(const char *text, int start, UNUSED(int end))
 }
 
 static void
-readline_init(const struct cmd_tbl_entry *curtable)
-{
+readline_init(const struct cmd_tbl_entry *curtable) {
 	//preset levels for current table
 	current_cmd_level = curtable;
 	completion_cmd_level = curtable;
@@ -313,8 +307,7 @@ readline_init(const struct cmd_tbl_entry *curtable)
 #else	// so no libreadline
 
 static char *
-get_input(const char *prompt)
-{
+get_input(const char *prompt) {
 	return basic_get_input(prompt, stdin);
 }
 
@@ -323,8 +316,7 @@ static void readline_init(UNUSED(const struct cmd_tbl_entry *cmd_table)) {}
 #endif	//HAVE_LIBREADLINE
 
 static char *
-command_line_input(const char *prompt, FILE *instream)
-{
+command_line_input(const char *prompt, FILE *instream) {
 	if (instream == stdin) {
 		return get_input(prompt);
 	}
@@ -334,8 +326,7 @@ command_line_input(const char *prompt, FILE *instream)
 }
 
 int
-help_common(int argc, char **argv, const struct cmd_tbl_entry *cmd_table)
-{
+help_common(int argc, char **argv, const struct cmd_tbl_entry *cmd_table) {
 /*	int i;*/
 	const struct cmd_tbl_entry *ctp;
 
@@ -382,15 +373,13 @@ help_common(int argc, char **argv, const struct cmd_tbl_entry *cmd_table)
 }
 
 static int
-cmd_help(int argc, char **argv)
-{
+cmd_help(int argc, char **argv) {
 	return help_common(argc, argv, root_cmd_table);
 }
 
 
 static int
-cmd_date(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_date(UNUSED(int argc), UNUSED(char **argv)) {
 	struct tm *tm;
 	time_t now;
 
@@ -403,15 +392,13 @@ cmd_date(UNUSED(int argc), UNUSED(char **argv))
 
 
 static int
-cmd_rem(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_rem(UNUSED(int argc), UNUSED(char **argv)) {
 	return CMD_OK;
 }
 
 
 void
-log_timestamp(const char *prefix)
-{
+log_timestamp(const char *prefix) {
 	unsigned long tv;
 
 	tv = diag_os_getms() - global_log_tstart;
@@ -420,8 +407,7 @@ log_timestamp(const char *prefix)
 }
 
 static void
-log_command(int argc, char **argv)
-{
+log_command(int argc, char **argv) {
 	int i;
 
 	if (!global_logfp)
@@ -434,8 +420,7 @@ log_command(int argc, char **argv)
 }
 
 static int
-cmd_log(int argc, char **argv)
-{
+cmd_log(int argc, char **argv) {
 	char autofilename[20]="";
 	char *file;
 	time_t now;
@@ -490,8 +475,7 @@ cmd_log(int argc, char **argv)
 
 
 static int
-cmd_stoplog(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_stoplog(UNUSED(int argc), UNUSED(char **argv)) {
 	/* Turn off logging */
 	if (global_logfp == NULL) {
 		printf("Logging was not on\n");
@@ -505,8 +489,7 @@ cmd_stoplog(UNUSED(int argc), UNUSED(char **argv))
 }
 
 static int
-cmd_play(int argc, char **argv)
-{
+cmd_play(int argc, char **argv) {
 	FILE *fp;
 	//int linenr;
 
@@ -584,8 +567,7 @@ static const struct cmd_tbl_entry *find_cmd(const struct cmd_tbl_entry *cmdt, co
  * If argc is supplied, then this is one shot cli, ie run the command
  */
 static int
-do_cli(const struct cmd_tbl_entry *cmd_tbl, const char *prompt, FILE *instream, int argc, char **argv)
-{
+do_cli(const struct cmd_tbl_entry *cmd_tbl, const char *prompt, FILE *instream, int argc, char **argv) {
 	/* Build up argc/argv */
 	const struct cmd_tbl_entry *ctp;
 	int cmd_argc;
@@ -596,7 +578,7 @@ do_cli(const struct cmd_tbl_entry *cmd_tbl, const char *prompt, FILE *instream, 
 	int i;
 
 	char promptbuf[PROMPTBUFSIZE];	/* Was 1024, who needs that long a prompt? (the part before user input up to '>') */
-	static char nullstr[2]={0,0};
+	static char nullstr[2] = {0,0};
 
 #ifdef HAVE_LIBREADLINE
 	//set the current command level for command completion
@@ -621,13 +603,11 @@ do_cli(const struct cmd_tbl_entry *cmd_tbl, const char *prompt, FILE *instream, 
 
 			/* Parse it */
 			inptr = input;
-			if (*inptr == '@') 	//printing comment
-			{
+			if (*inptr == '@') {	//printing comment
 				printf("%s\n", inptr);
 				continue;
 			}
-			if (*inptr == '#')		//non-printing comment
-			{
+			if (*inptr == '#') {		//non-printing comment
 				continue;
 			}
 			cmd_argc = 0;
@@ -731,8 +711,7 @@ do_cli(const struct cmd_tbl_entry *cmd_tbl, const char *prompt, FILE *instream, 
  * ret CMD_FAILED if file was unreadable
  * forward CMD_EXIT if applicable */
 static int
-command_file(const char *filename)
-{
+command_file(const char *filename) {
 	int rv;
 	FILE *fstream;
 
@@ -745,8 +724,7 @@ command_file(const char *filename)
 }
 
 static int
-cmd_source(int argc, char **argv)
-{
+cmd_source(int argc, char **argv) {
 	char *file;
 	int rv;
 
@@ -766,8 +744,7 @@ cmd_source(int argc, char **argv)
 
 //rc_file : returns CMD_OK or CMD_EXIT only.
 static int
-rc_file(void)
-{
+rc_file(void) {
 	int rv;
 	//this loads either a $home/.<progname>.rc or ./<progname>.ini (in order of preference)
 	//to load general settings.
@@ -846,8 +823,7 @@ rc_file(void)
 
 /* start a cli with <name> as a prompt, and optionally run the <initscript> file */
 void
-enter_cli(const char *name, const char *initscript, const struct cmd_tbl_entry *extra_cmdtable)
-{
+enter_cli(const char *name, const char *initscript, const struct cmd_tbl_entry *extra_cmdtable) {
 	int rc_rv=CMD_OK;
 	global_logfp = NULL;
 	progname = name;
@@ -919,8 +895,7 @@ exit_cleanup:
  * [-][0-9] : dec
  * Returns 0 if unable to decode.
  */
-int htoi(char *buf)
-{
+int htoi(char *buf) {
 	/* Hex text to int */
 	int rv = 0;
 	int base = 10;
@@ -970,8 +945,7 @@ int htoi(char *buf)
 /*
  * Wait until ENTER is pressed
  */
-void wait_enter(const char *message)
-{
+void wait_enter(const char *message) {
 	printf(message);
 	while (1) {
 		int ch = getc(stdin);
@@ -983,21 +957,18 @@ void wait_enter(const char *message)
 /*
  * Determine whether ENTER has been pressed
  */
-int pressed_enter()
-{
+int pressed_enter() {
 	return diag_os_ipending();
 }
 
 
 int
-cmd_up(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_up(UNUSED(int argc), UNUSED(char **argv)) {
 	return CMD_UP;
 }
 
 
 int
-cmd_exit(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_exit(UNUSED(int argc), UNUSED(char **argv)) {
 	return CMD_EXIT;
 }

--- a/scantool/scantool_cli.h
+++ b/scantool/scantool_cli.h
@@ -33,8 +33,7 @@
 extern "C" {
 #endif
 
-typedef struct cmd_tbl_entry
-{
+typedef struct cmd_tbl_entry {
 	const char *command;		/* Command name */
 	const char *usage;		/* Usage info */
 	const char *help;		/* Help Text */

--- a/scantool/scantool_debug.c
+++ b/scantool/scantool_debug.c
@@ -38,7 +38,7 @@
 
 //declare an array of structs to associate debug flag masks with short description.
 //See diag.h
-const struct debugflags_descr debugflags[]={
+const struct debugflags_descr debugflags[] = {
 	{OPEN, "Open events","OPEN"},
 	{CLOSE, "Close events","CLOSE"},
 	{READ, "Read events","READ"},
@@ -62,8 +62,7 @@ static int cmd_debug_l3(int argc, char **argv);
 static int cmd_debug_all(int argc, char **argv);
 static int cmd_debug_l0test(int argc, char **argv);
 
-const struct cmd_tbl_entry debug_cmd_table[] =
-{
+const struct cmd_tbl_entry debug_cmd_table[] = {
 	{ "help", "help [command]", "Gives help for a command",
 		cmd_debug_help, 0, NULL},
 	{ "?", "? [command]", "Gives help for a command",
@@ -97,8 +96,7 @@ const struct cmd_tbl_entry debug_cmd_table[] =
 };
 
 static int
-cmd_debug_help(int argc, char **argv)
-{
+cmd_debug_help(int argc, char **argv) {
 	if (argc<2) {
 		printf("Debugging flags are set per level according to the values set in diag.h\n");
 		printf("Setting [val] to -1 will enable all debug messages for that level.\n"
@@ -114,8 +112,7 @@ cmd_debug_help(int argc, char **argv)
 
 
 static int
-cmd_debug_common( const char *txt, int *val, int argc, char **argv)
-{
+cmd_debug_common( const char *txt, int *val, int argc, char **argv) {
 	int r;
 	int i;
 
@@ -137,35 +134,29 @@ cmd_debug_common( const char *txt, int *val, int argc, char **argv)
 }
 
 static int
-cmd_debug_l0(int argc, char **argv)
-{
+cmd_debug_l0(int argc, char **argv) {
 	return cmd_debug_common("L0", &diag_l0_debug, argc, argv);
 }
 static int
-cmd_debug_l1(int argc, char **argv)
-{
+cmd_debug_l1(int argc, char **argv) {
 	return cmd_debug_common("L1", &diag_l1_debug, argc, argv);
 }
 static int
-cmd_debug_l2(int argc, char **argv)
-{
+cmd_debug_l2(int argc, char **argv) {
 	return cmd_debug_common("L2", &diag_l2_debug, argc, argv);
 }
 static int
-cmd_debug_l3(int argc, char **argv)
-{
+cmd_debug_l3(int argc, char **argv) {
 	return cmd_debug_common("L3", &diag_l3_debug, argc, argv);
 }
 static int
-cmd_debug_cli(int argc, char **argv)
-{
+cmd_debug_cli(int argc, char **argv) {
 	return cmd_debug_common("CLI", &diag_cli_debug, argc, argv);
 	//for now, value > 0x80 will enable all debugging info.
 }
 
 static int
-cmd_debug_all(int argc, char **argv)
-{
+cmd_debug_all(int argc, char **argv) {
 	int val;
 
 	if (argc > 0) {
@@ -183,8 +174,7 @@ cmd_debug_all(int argc, char **argv)
 
 
 static int
-cmd_debug_show(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_debug_show(UNUSED(int argc), UNUSED(char **argv)) {
 /*	int layer, val; */
 
 	printf("Debug values: L0 0x%X, L1 0x%X, L2 0x%X L3 0x%X CLI 0x%X\n",

--- a/scantool/scantool_diag.c
+++ b/scantool/scantool_diag.c
@@ -53,8 +53,7 @@ static int cmd_diag_reml3(UNUSED(int argc), UNUSED(char **argv));
 static int cmd_diag_probe(int argc, char **argv);
 static int cmd_diag_fastprobe(int argc, char **argv);
 
-const struct cmd_tbl_entry diag_cmd_table[] =
-{
+const struct cmd_tbl_entry diag_cmd_table[] = {
 	{ "help", "help [command]", "Gives help for a command",
 		cmd_diag_help, 0, NULL},
 	{ "?", "? [command]", "Gives help for a command",
@@ -93,14 +92,12 @@ const struct cmd_tbl_entry diag_cmd_table[] =
 };
 
 static int
-cmd_diag_help(int argc, char **argv)
-{
+cmd_diag_help(int argc, char **argv) {
 	return help_common(argc, argv, diag_cmd_table);
 }
 
 static int
-cmd_diag_addl3(int argc, char **argv)
-{
+cmd_diag_addl3(int argc, char **argv) {
 	int i;
 	const char *proto;
 
@@ -191,8 +188,7 @@ static int cmd_diag_reml3(UNUSED(int argc), UNUSED(char **argv)) {
 //This should stop searching at the first succesful init
 //and update the global connection
 static int
-cmd_diag_probe_common(int argc, char **argv, int fastflag)
-{
+cmd_diag_probe_common(int argc, char **argv, int fastflag) {
 	unsigned int start, end, i;
 	int rv;
 	struct diag_l0_device *dl0d = global_dl0d;
@@ -315,14 +311,12 @@ cmd_diag_probe_common(int argc, char **argv, int fastflag)
 }
 
 static int
-cmd_diag_probe(int argc, char **argv)
-{
+cmd_diag_probe(int argc, char **argv) {
 	return cmd_diag_probe_common(argc, argv, 0);
 }
 
 static int
-cmd_diag_fastprobe(int argc, char **argv)
-{
+cmd_diag_fastprobe(int argc, char **argv) {
 	return cmd_diag_probe_common(argc, argv, 1);
 }
 
@@ -332,8 +326,7 @@ cmd_diag_fastprobe(int argc, char **argv)
  * Currently only called from cmd_diag_connect;
  */
 static int
-do_l2_generic_start(void)
-{
+do_l2_generic_start(void) {
 	struct diag_l2_conn *d_conn;
 	struct diag_l0_device *dl0d = global_dl0d;
 	int rv;
@@ -387,8 +380,7 @@ do_l2_generic_start(void)
 //cmd_diag_connect : attempt to connect to ECU
 //using the current global l2proto, l1proto, etc.
 static int
-cmd_diag_connect(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_diag_connect(UNUSED(int argc), UNUSED(char **argv)) {
 	int rv;
 
 	if (argc > 1) {
@@ -418,8 +410,7 @@ cmd_diag_connect(UNUSED(int argc), UNUSED(char **argv))
 //Currently, this stops + removes the current global L3 conn.
 //If there are no more L3 conns, also stop + close the global L2 conn.
 static int
-cmd_diag_disconnect(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_diag_disconnect(UNUSED(int argc), UNUSED(char **argv)) {
 	if (argc > 1) {
 		return CMD_USAGE;
 	}
@@ -452,8 +443,7 @@ cmd_diag_disconnect(UNUSED(int argc), UNUSED(char **argv))
 
 
 static int
-cmd_diag_read(int argc, char **argv)
-{
+cmd_diag_read(int argc, char **argv) {
 	unsigned int timeout = 0;
 
 	if (global_state < STATE_CONNECTED) {
@@ -480,8 +470,7 @@ cmd_diag_read(int argc, char **argv)
  * Send some data, and wait for a response
  */
 static int
-cmd_diag_sendreq(int argc, char **argv)
-{
+cmd_diag_sendreq(int argc, char **argv) {
 	uint8_t	data[MAXRBUF];
 	unsigned int	i,j,len;
 	int	rv;

--- a/scantool/scantool_dyno.c
+++ b/scantool/scantool_dyno.c
@@ -47,7 +47,7 @@
 
 
 
-dyno_result * dyno_results;
+dyno_result *dyno_results;
 int dyno_nb_results;
 
 static int cmd_dyno_help(int argc, char **argv);
@@ -531,7 +531,7 @@ static int cmd_dyno_run(UNUSED(int argc), UNUSED(char **argv)) {
  *****************************************************************************/
 
 /* Get measures for specified type */
-static void get_measures(dyno_measure ** measures, int * nb_measures) {
+static void get_measures(dyno_measure **measures, int *nb_measures) {
 	/* allocate memory */
 	(*nb_measures) = dyno_get_nb_measures();
 	if ((*nb_measures)==0)
@@ -544,7 +544,7 @@ static void get_measures(dyno_measure ** measures, int * nb_measures) {
 }
 
 /* Display given measures */
-static void display_measures(dyno_measure * measures, int nb_measures) {
+static void display_measures(dyno_measure *measures, int nb_measures) {
 	int i;
 
 	for (i=0; i<nb_measures; i++) {
@@ -563,7 +563,7 @@ static void display_measures(dyno_measure * measures, int nb_measures) {
 /* Display all measures */
 
 static int cmd_dyno_measures(UNUSED(int argc), UNUSED(char **argv)) {
-	dyno_measure * measures = NULL;
+	dyno_measure *measures = NULL;
 	int nb_measures = 0;
 
 	printf("Dyno measures :\n");
@@ -579,7 +579,7 @@ static int cmd_dyno_measures(UNUSED(int argc), UNUSED(char **argv)) {
 
 
 /* Display results */
-static void display_results(dyno_result * results, int nb) {
+static void display_results(dyno_result *results, int nb) {
 	int i;
 
 	int max_power_i = 0;
@@ -615,7 +615,7 @@ static void display_results(dyno_result * results, int nb) {
 #define DYNO_GRAPH_HEIGHT 21
 
 /* Display graphs */
-static void display_graphs(dyno_result * results, int nb) {
+static void display_graphs(dyno_result *results, int nb) {
 	int row, col, step;
 
 	int max_power_i = 0;
@@ -740,7 +740,7 @@ static int cmd_dyno_graph(UNUSED(int argc), UNUSED(char **argv)) {
  * Save dyno measures and results to a file
  */
 static int cmd_dyno_save(int argc, char **argv) {
-	char * filename;
+	char *filename;
 
 	get_results();
 

--- a/scantool/scantool_dyno.c
+++ b/scantool/scantool_dyno.c
@@ -62,8 +62,7 @@ static int cmd_dyno_save(int argc, char **argv);
 
 void reset_results(void);
 
-const struct cmd_tbl_entry dyno_cmd_table[] =
-{
+const struct cmd_tbl_entry dyno_cmd_table[] = {
 	{ "help", "help [command]", "Gives help for a command",
 		cmd_dyno_help, 0, NULL},
 	{ "?", "? [command]", "Gives help for a command",
@@ -100,8 +99,7 @@ const struct cmd_tbl_entry dyno_cmd_table[] =
 /*
  * Show/Sets the mass of the vehicle
  */
-static int cmd_dyno_mass(int argc, char **argv)
-{
+static int cmd_dyno_mass(int argc, char **argv) {
 	int mass=0;
 
 	if (argc > 1)
@@ -130,8 +128,7 @@ static int cmd_dyno_mass(int argc, char **argv)
 
 /* measure speed */
 // return <0 if error
-static int measure_data(uint8_t data_pid, ecu_data_t *ep)
-{
+static int measure_data(uint8_t data_pid, ecu_data_t *ep) {
 	int rv;
 
 	if (global_l3_conn == NULL) {
@@ -161,8 +158,7 @@ int counter;
 unsigned long tv0d;	/* measuring time */
 
 /* fake loss measures */
-int fake_loss_measure_data()
-{
+int fake_loss_measure_data() {
 	unsigned long tv;
 	unsigned long elapsed; /* elapsed time */
 	int speed;
@@ -238,8 +234,7 @@ int fake_loss_measure_data()
 
 int counter2;
 /* fake run measures */
-int fake_run_measure_data(int data_pid)
-{
+int fake_run_measure_data(int data_pid) {
   int rpm;
 
   diag_os_millisleep(250);
@@ -278,8 +273,7 @@ int dyno_loss_done;
  * Determine power lost by aerodynamic and friction forces
  */
 
-static int cmd_dyno_loss(UNUSED(int argc), UNUSED(char **argv))
-{
+static int cmd_dyno_loss(UNUSED(int argc), UNUSED(char **argv)) {
 	ecu_data_t *ep;
 
 	int speed;              /* measured speed */
@@ -385,8 +379,7 @@ static int cmd_dyno_loss(UNUSED(int argc), UNUSED(char **argv))
 /*
  * Manually enter aerodynamic and friction forces d and f parameters
  */
-static int cmd_dyno_setloss(int argc, char **argv)
-{
+static int cmd_dyno_setloss(int argc, char **argv) {
 	if (argc > 1) {
 		int assigned;
 		double d;
@@ -424,8 +417,7 @@ static int cmd_dyno_setloss(int argc, char **argv)
  * Run dyno
  */
 
-static int cmd_dyno_run(UNUSED(int argc), UNUSED(char **argv))
-{
+static int cmd_dyno_run(UNUSED(int argc), UNUSED(char **argv)) {
 	ecu_data_t *ep;
 
 	int speed;						/* measured speed */
@@ -539,8 +531,7 @@ static int cmd_dyno_run(UNUSED(int argc), UNUSED(char **argv))
  *****************************************************************************/
 
 /* Get measures for specified type */
-static void get_measures(dyno_measure ** measures, int * nb_measures)
-{
+static void get_measures(dyno_measure ** measures, int * nb_measures) {
 	/* allocate memory */
 	(*nb_measures) = dyno_get_nb_measures();
 	if ((*nb_measures)==0)
@@ -553,8 +544,7 @@ static void get_measures(dyno_measure ** measures, int * nb_measures)
 }
 
 /* Display given measures */
-static void display_measures(dyno_measure * measures, int nb_measures)
-{
+static void display_measures(dyno_measure * measures, int nb_measures) {
 	int i;
 
 	for (i=0; i<nb_measures; i++) {
@@ -572,8 +562,7 @@ static void display_measures(dyno_measure * measures, int nb_measures)
 
 /* Display all measures */
 
-static int cmd_dyno_measures(UNUSED(int argc), UNUSED(char **argv))
-{
+static int cmd_dyno_measures(UNUSED(int argc), UNUSED(char **argv)) {
 	dyno_measure * measures = NULL;
 	int nb_measures = 0;
 
@@ -590,8 +579,7 @@ static int cmd_dyno_measures(UNUSED(int argc), UNUSED(char **argv))
 
 
 /* Display results */
-static void display_results(dyno_result * results, int nb)
-{
+static void display_results(dyno_result * results, int nb) {
 	int i;
 
 	int max_power_i = 0;
@@ -627,8 +615,7 @@ static void display_results(dyno_result * results, int nb)
 #define DYNO_GRAPH_HEIGHT 21
 
 /* Display graphs */
-static void display_graphs(dyno_result * results, int nb)
-{
+static void display_graphs(dyno_result * results, int nb) {
 	int row, col, step;
 
 	int max_power_i = 0;
@@ -685,8 +672,7 @@ static void display_graphs(dyno_result * results, int nb)
 }
 
 /* Get the results in global vars */
-static void get_results(void)
-{
+static void get_results(void) {
 	/* allocating memory for the results table */
 	if (dyno_results == NULL) {
 		dyno_nb_results = dyno_get_nb_results();
@@ -704,8 +690,7 @@ static void get_results(void)
 }
 
 /* Reset results */
-void reset_results(void)
-{
+void reset_results(void) {
 	if (dyno_results != NULL)
 		free(dyno_results);
 	dyno_results = NULL;
@@ -716,8 +701,7 @@ void reset_results(void)
  * Display dyno results
  */
 
-static int cmd_dyno_result(UNUSED(int argc), UNUSED(char **argv))
-{
+static int cmd_dyno_result(UNUSED(int argc), UNUSED(char **argv)) {
 	get_results();
 
 	/* Check data */
@@ -734,8 +718,7 @@ static int cmd_dyno_result(UNUSED(int argc), UNUSED(char **argv))
  * Display dyno graphs
  */
 
-static int cmd_dyno_graph(UNUSED(int argc), UNUSED(char **argv))
-{
+static int cmd_dyno_graph(UNUSED(int argc), UNUSED(char **argv)) {
 	get_results();
 
 	/* Check data */
@@ -756,8 +739,7 @@ static int cmd_dyno_graph(UNUSED(int argc), UNUSED(char **argv))
 /*
  * Save dyno measures and results to a file
  */
-static int cmd_dyno_save(int argc, char **argv)
-{
+static int cmd_dyno_save(int argc, char **argv) {
 	char * filename;
 
 	get_results();
@@ -787,8 +769,7 @@ static int cmd_dyno_save(int argc, char **argv)
 
 		/* Remove pending "\n" and "\r", if any */
 		while ((filename[strlen(filename)-1] == '\n') ||
-					 (filename[strlen(filename)-1] == '\r'))
-		{
+					 (filename[strlen(filename)-1] == '\r')) {
 			filename[strlen(filename)-1] = '\0';
 		}
 	}
@@ -803,7 +784,6 @@ static int cmd_dyno_save(int argc, char **argv)
 
 /* Display help */
 static int
-cmd_dyno_help(int argc, char **argv)
-{
+cmd_dyno_help(int argc, char **argv) {
 	return help_common(argc, argv, dyno_cmd_table);
 }

--- a/scantool/scantool_obd.c
+++ b/scantool/scantool_obd.c
@@ -401,8 +401,7 @@ print_resp_info(UNUSED(int mode), response_t *data) {
 				printf("0x%02X: ", i );
 				diag_data_dump(stdout, data->data, data->len);
 				printf("\n");
-			}
-			else
+			} else
 				printf("0x%02X: Failed 0x%X\n",
 					i, data->data[1]);
 		}

--- a/scantool/scantool_obd.c
+++ b/scantool/scantool_obd.c
@@ -21,8 +21,7 @@
 
 //cmd_watch : this creates a diag_l3_conn
 static int
-cmd_watch(int argc, char **argv)
-{
+cmd_watch(int argc, char **argv) {
 	int rv;
 	struct diag_l2_conn *d_l2_conn;
 	struct diag_l3_conn *d_l3_conn=NULL;
@@ -155,8 +154,7 @@ cmd_watch(int argc, char **argv)
  * units
  */
 static void
-print_current_data(bool english)
-{
+print_current_data(bool english) {
 	char buf[24];
 	ecu_data_t *ep;
 	unsigned int i;
@@ -194,8 +192,7 @@ print_current_data(bool english)
 }
 
 static void
-log_response(int ecu, response_t *r)
-{
+log_response(int ecu, response_t *r) {
 	assert(global_logfp != NULL);
 
 	/* Only print good records */
@@ -208,8 +205,7 @@ log_response(int ecu, response_t *r)
 }
 
 static void
-log_current_data(void)
-{
+log_current_data(void) {
 	response_t *r;
 	ecu_data_t *ep;
 	unsigned int i;
@@ -237,8 +233,7 @@ log_current_data(void)
 }
 
 static int
-cmd_monitor(int argc, char **argv)
-{
+cmd_monitor(int argc, char **argv) {
 	int rv;
 	bool english = 0;
 
@@ -292,8 +287,7 @@ cmd_monitor(int argc, char **argv)
 // scan : use existing L3 J1979 connection, or establish a new one by trying all known protos.
 
 static int
-cmd_scan(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_scan(UNUSED(int argc), UNUSED(char **argv)) {
 	int rv=DIAG_ERR_GENERAL;
 	if (argc > 1)
 		return CMD_USAGE;
@@ -347,8 +341,7 @@ cmd_scan(UNUSED(int argc), UNUSED(char **argv))
 
 
 static int
-cmd_cleardtc(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_cleardtc(UNUSED(int argc), UNUSED(char **argv)) {
 	char *input;
 
 	if (global_state < STATE_CONNECTED) {
@@ -377,8 +370,7 @@ cmd_cleardtc(UNUSED(int argc), UNUSED(char **argv))
 
 
 static int
-cmd_ecus(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_ecus(UNUSED(int argc), UNUSED(char **argv)) {
 	ecu_data_t *ep;
 	unsigned int i;
 
@@ -400,16 +392,12 @@ cmd_ecus(UNUSED(int argc), UNUSED(char **argv))
 }
 
 static void
-print_resp_info(UNUSED(int mode), response_t *data)
-{
+print_resp_info(UNUSED(int mode), response_t *data) {
 
 	int i;
-	for (i=0; i<256; i++)
-	{
-		if (data->type != TYPE_UNTESTED)
-		{
-			if (data->type == TYPE_GOOD)
-			{
+	for (i=0; i<256; i++) {
+		if (data->type != TYPE_UNTESTED) {
+			if (data->type == TYPE_GOOD) {
 				printf("0x%02X: ", i );
 				diag_data_dump(stdout, data->data, data->len);
 				printf("\n");
@@ -424,26 +412,21 @@ print_resp_info(UNUSED(int mode), response_t *data)
 
 
 static int
-cmd_dumpdata(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_dumpdata(UNUSED(int argc), UNUSED(char **argv)) {
 	ecu_data_t *ep;
 	int i;
 
 	printf("Current Data\n");
-	for (i=0, ep=ecu_info; i<MAX_ECU; i++,ep++)
-	{
-		if (ep->valid)
-		{
+	for (i=0, ep=ecu_info; i<MAX_ECU; i++,ep++) {
+		if (ep->valid) {
 			printf("ECU 0x%02X:\n", ep->ecu_addr & 0xff);
 			print_resp_info(1, ep->mode1_data);
 		}
 	}
 
 	printf("Freezeframe Data\n");
-	for (i=0,ep=ecu_info; i<MAX_ECU; i++,ep++)
-	{
-		if (ep->valid)
-		{
+	for (i=0,ep=ecu_info; i<MAX_ECU; i++,ep++) {
+		if (ep->valid) {
 			printf("ECU 0x%02X:\n", ep->ecu_addr & 0xff);
 			print_resp_info(2, ep->mode2_data);
 		}
@@ -457,8 +440,7 @@ cmd_dumpdata(UNUSED(int argc), UNUSED(char **argv))
 
 /*print_pidinfo() : print supported PIDs (0 to 0x60) */
 static void
-print_pidinfo(int mode, uint8_t *pid_data)
-{
+print_pidinfo(int mode, uint8_t *pid_data) {
 	int i,j;	/* j : # pid per line */
 
 	printf(" Mode %d:", mode);
@@ -475,21 +457,17 @@ print_pidinfo(int mode, uint8_t *pid_data)
 }
 
 
-static int cmd_pids(UNUSED(int argc), UNUSED(char **argv))
-{
+static int cmd_pids(UNUSED(int argc), UNUSED(char **argv)) {
 	ecu_data_t *ep;
 	int i;
 
-	if (global_state < STATE_SCANDONE)
-	{
+	if (global_state < STATE_SCANDONE) {
 		printf("SCAN has not been done, please do a scan\n");
 		return CMD_OK;
 	}
 
-	for (i=0,ep=ecu_info; i<MAX_ECU; i++,ep++)
-	{
-		if (ep->valid)
-		{
+	for (i=0,ep=ecu_info; i<MAX_ECU; i++,ep++) {
+		if (ep->valid) {
 			printf("ECU %d address 0x%02X: Supported PIDs:\n",
 				i, ep->ecu_addr & 0xff);
 			print_pidinfo(1, ep->mode1_info);
@@ -505,8 +483,7 @@ static int cmd_pids(UNUSED(int argc), UNUSED(char **argv))
 	return CMD_OK;
 }
 
-const struct cmd_tbl_entry scantool_cmd_table[]=
-{
+const struct cmd_tbl_entry scantool_cmd_table[] = {
 	{ "scan", "scan", "Start SCAN process", cmd_scan, 0, NULL},
 	{ "monitor", "monitor [english/metric]", "Continuously monitor rpm etc",
 		cmd_monitor, 0, NULL},

--- a/scantool/scantool_set.c
+++ b/scantool/scantool_set.c
@@ -49,8 +49,7 @@ struct diag_l0_device *global_dl0d;
 /*
  * XXX All commands should probably have optional "init" hooks.
  */
-int set_init(void)
-{
+int set_init(void) {
 	/* Reset parameters to defaults. */
 
 	global_cfg.speed = 10400;	/* Comms speed; ECUs will probably send at 10416 bps (96us per bit) */
@@ -77,8 +76,7 @@ int set_init(void)
 	return 0;
 }
 
-void set_close(void)
-{
+void set_close(void) {
 	return;
 }
 
@@ -98,8 +96,7 @@ static int cmd_set_initmode(int argc, char **argv);
 static int cmd_set_display(int argc, char **argv);
 static int cmd_set_interface(int argc, char **argv);
 
-const struct cmd_tbl_entry set_cmd_table[] =
-{
+const struct cmd_tbl_entry set_cmd_table[] = {
 	{ "help", "help [command]", "Gives help for a command",
 		cmd_set_help, 0, NULL},
 	{ "?", "help [command]", "Gives help for a command",
@@ -145,16 +142,14 @@ const struct cmd_tbl_entry set_cmd_table[] =
 	{ NULL, NULL, NULL, NULL, 0, NULL}
 };
 
-const char * const l1_names[] = //these MUST be in the same order as they are listed in diag_l1.h !!
-{
+const char * const l1_names[] = { //these MUST be in the same order as they are listed in diag_l1.h !!
 	"ISO9141", "ISO14230",
 	"J1850-VPW", "J1850-PWM", "CAN", "", "", "RAW", NULL
 };
 
 //These MUST match the DIAG_L2_TYPE_* flags in diag_l2.h  so that
 // l2_initmodes[DIAG_L2_TYPE_XX] == "XX" !!
-const char * const l2_initmodes[] =
-{
+const char * const l2_initmodes[] = {
 	"5BAUD", "FAST", "CARB", NULL
 };
 
@@ -249,8 +244,7 @@ static int cmd_set_custom(int argc, char **argv) {
 }
 
 static int
-cmd_set_show(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_set_show(UNUSED(int argc), UNUSED(char **argv)) {
 	/* Show stuff; calling the cmd_set_*() functions with argc=0 displays the current setting. */
 	cmd_set_interface(0,NULL);
 	cmd_set_speed(0, NULL);
@@ -279,8 +273,7 @@ cmd_set_show(UNUSED(int argc), UNUSED(char **argv))
 }
 
 
-static int cmd_set_interface(int argc, char **argv)
-{
+static int cmd_set_interface(int argc, char **argv) {
 	const struct diag_l0 *iter;
 
 	if (argc <= 1) {
@@ -345,8 +338,7 @@ static int cmd_set_interface(int argc, char **argv)
 }
 
 static int
-cmd_set_display(int argc, char **argv)
-{
+cmd_set_display(int argc, char **argv) {
 	if (argc > 1) {
 		if (strcasecmp(argv[1], "english") == 0)
 			global_cfg.units = 1;
@@ -362,8 +354,7 @@ cmd_set_display(int argc, char **argv)
 }
 
 static int
-cmd_set_speed(int argc, char **argv)
-{
+cmd_set_speed(int argc, char **argv) {
 	if (argc > 1) {
 		if (strcmp(argv[1], "?") == 0) {
 			return CMD_USAGE;
@@ -377,8 +368,7 @@ cmd_set_speed(int argc, char **argv)
 }
 
 static int
-cmd_set_testerid(int argc, char **argv)
-{
+cmd_set_testerid(int argc, char **argv) {
 	if (argc > 1) {
 		int tmp;
 		if (strncmp(argv[1], "?", 1) == 0) {
@@ -397,8 +387,7 @@ cmd_set_testerid(int argc, char **argv)
 }
 
 static int
-cmd_set_destaddr(int argc, char **argv)
-{
+cmd_set_destaddr(int argc, char **argv) {
 	if (argc > 1) {
 		int tmp;
 		if (strncmp(argv[1], "?", 1) == 0) {
@@ -418,8 +407,7 @@ cmd_set_destaddr(int argc, char **argv)
 }
 
 static int
-cmd_set_addrtype(int argc, char **argv)
-{
+cmd_set_addrtype(int argc, char **argv) {
 	if (argc > 1) {
 		if (strncmp(argv[1], "func", 4) == 0)
 			global_cfg.addrtype = 1;
@@ -435,8 +423,7 @@ cmd_set_addrtype(int argc, char **argv)
 	return CMD_OK;
 }
 
-static int cmd_set_l2protocol(int argc, char **argv)
-{
+static int cmd_set_l2protocol(int argc, char **argv) {
 	if (argc > 1) {
 		int i, helping = 0, found = 0;
 		if (strcmp(argv[1], "?") == 0) {
@@ -471,21 +458,18 @@ static int cmd_set_l2protocol(int argc, char **argv)
 	return CMD_OK;
 }
 
-static int cmd_set_l1protocol(int argc, char **argv)
-{
+static int cmd_set_l1protocol(int argc, char **argv) {
 	if (argc > 1) {
 		int i, helping = 0, found = 0;
 		if (strcmp(argv[1], "?") == 0) {
 			helping = 1;
 			printf("L1 protocol: valid names are ");
 		}
-		for (i=0; l1_names[i] != NULL; i++)
-		{
+		for (i=0; l1_names[i] != NULL; i++) {
 			if (helping && *l1_names[i])
 				printf("%s ", l1_names[i]);
 			else
-				if (strcasecmp(argv[1], l1_names[i]) == 0)
-				{
+				if (strcasecmp(argv[1], l1_names[i]) == 0) {
 					global_cfg.L1proto = 1 << i;
 					found = 1;
 				}
@@ -513,8 +497,7 @@ static int cmd_set_l1protocol(int argc, char **argv)
 	return CMD_OK;
 }
 
-static int cmd_set_initmode(int argc, char **argv)
-{
+static int cmd_set_initmode(int argc, char **argv) {
 	if (argc > 1) {
 		int i, helping = 0, found = 0;
 		if (strcmp(argv[1], "?") == 0) {
@@ -548,7 +531,6 @@ static int cmd_set_initmode(int argc, char **argv)
 }
 
 static int
-cmd_set_help(int argc, char **argv)
-{
+cmd_set_help(int argc, char **argv) {
 	return help_common(argc, argv, set_cmd_table);
 }

--- a/scantool/scantool_set.c
+++ b/scantool/scantool_set.c
@@ -142,14 +142,14 @@ const struct cmd_tbl_entry set_cmd_table[] = {
 	{ NULL, NULL, NULL, NULL, 0, NULL}
 };
 
-const char * const l1_names[] = { //these MUST be in the same order as they are listed in diag_l1.h !!
+const char *const l1_names[] = { //these MUST be in the same order as they are listed in diag_l1.h !!
 	"ISO9141", "ISO14230",
 	"J1850-VPW", "J1850-PWM", "CAN", "", "", "RAW", NULL
 };
 
 //These MUST match the DIAG_L2_TYPE_* flags in diag_l2.h  so that
 // l2_initmodes[DIAG_L2_TYPE_XX] == "XX" !!
-const char * const l2_initmodes[] = {
+const char *const l2_initmodes[] = {
 	"5BAUD", "FAST", "CARB", NULL
 };
 

--- a/scantool/scantool_set.c
+++ b/scantool/scantool_set.c
@@ -346,8 +346,7 @@ cmd_set_display(int argc, char **argv) {
 			global_cfg.units = 0;
 		else
 			return CMD_USAGE;
-	}
-	else
+	} else
 		printf("display: %s units\n", global_cfg.units?"english":"metric");
 
 	return CMD_OK;

--- a/scantool/scantool_test.c
+++ b/scantool/scantool_test.c
@@ -249,8 +249,7 @@ cmd_test_readiness(UNUSED(int argc), UNUSED(char **argv)) {
 					supported = (ep->mode1_data[1].data[3]>>i)&1;
 					value = (ep->mode1_data[1].data[3]>>(i+4))&1;
 
-				}
-				else {
+				} else {
 					supported = (ep->mode1_data[1].data[4]>>(i-4))&1;
 					value = (ep->mode1_data[1].data[5]>>(i-4))&1;
 				}

--- a/scantool/scantool_test.c
+++ b/scantool/scantool_test.c
@@ -40,8 +40,7 @@ static int cmd_test_cms(int argc, char **argv);
 static int cmd_test_ncms(int argc, char **argv);
 static int cmd_test_readiness(int argc, char **argv);
 
-const struct cmd_tbl_entry test_cmd_table[] =
-{
+const struct cmd_tbl_entry test_cmd_table[] = {
 	{ "help", "help [command]", "Gives help for a command",
 		cmd_test_help, 0, NULL},
 	{ "?", "? [command]", "Gives help for a command",
@@ -69,8 +68,7 @@ const struct cmd_tbl_entry test_cmd_table[] =
 };
 
 static int
-cmd_test_help(int argc, char **argv)
-{
+cmd_test_help(int argc, char **argv) {
 	return help_common(argc, argv, test_cmd_table);
 }
 
@@ -80,8 +78,7 @@ cmd_test_help(int argc, char **argv)
  * return data length (excluding 0x00 termination) if ok (data written to *obuf)
  */
 static unsigned
-get_vit_info(struct diag_l3_conn *d_conn, uint8_t itype, uint8_t *obuf, unsigned buflen)
-{
+get_vit_info(struct diag_l3_conn *d_conn, uint8_t itype, uint8_t *obuf, unsigned buflen) {
 	struct diag_msg *msg, *msgcur;
 	int rv;
 	unsigned offset ;
@@ -94,7 +91,7 @@ get_vit_info(struct diag_l3_conn *d_conn, uint8_t itype, uint8_t *obuf, unsigned
 	}
 
 	msg = find_ecu_msg(0, 0x49);
-	if (msg == NULL){
+	if (msg == NULL) {
 		printf("No Mode 9 response\n");
 		return 0;
 	}
@@ -117,12 +114,10 @@ get_vit_info(struct diag_l3_conn *d_conn, uint8_t itype, uint8_t *obuf, unsigned
 /* Request Vehicle Info */
 
 static int
-cmd_test_rvi(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_test_rvi(UNUSED(int argc), UNUSED(char **argv)) {
 	struct diag_l3_conn *d_conn;
 
-	if (global_state < STATE_SCANDONE)
-	{
+	if (global_state < STATE_SCANDONE) {
 		printf("SCAN has not been done, please do a scan\n");
 		return CMD_OK;
 	}
@@ -180,10 +175,8 @@ cmd_test_rvi(UNUSED(int argc), UNUSED(char **argv))
 
 
 static int
-cmd_test_cms(UNUSED(int argc), UNUSED(char **argv))
-{
-	if (global_state < STATE_SCANDONE)
-	{
+cmd_test_cms(UNUSED(int argc), UNUSED(char **argv)) {
+	if (global_state < STATE_SCANDONE) {
 		printf("SCAN has not been done, please do a scan\n");
 		return CMD_OK;
 	}
@@ -193,10 +186,8 @@ cmd_test_cms(UNUSED(int argc), UNUSED(char **argv))
 
 
 static int
-cmd_test_ncms(UNUSED(int argc), UNUSED(char **argv))
-{
-	if (global_state < STATE_SCANDONE)
-	{
+cmd_test_ncms(UNUSED(int argc), UNUSED(char **argv)) {
+	if (global_state < STATE_SCANDONE) {
 		printf("SCAN has not been done, please do a scan\n");
 		return CMD_OK;
 	}
@@ -206,8 +197,7 @@ cmd_test_ncms(UNUSED(int argc), UNUSED(char **argv))
 
 
 static int
-cmd_test_readiness(UNUSED(int argc), UNUSED(char **argv))
-{
+cmd_test_readiness(UNUSED(int argc), UNUSED(char **argv)) {
 	int rv;
 	struct diag_l3_conn *d_conn;
 	ecu_data_t *ep;
@@ -231,8 +221,7 @@ cmd_test_readiness(UNUSED(int argc), UNUSED(char **argv))
 
 	d_conn = global_l3_conn;
 
-	if (global_state < STATE_CONNECTED)
-	{
+	if (global_state < STATE_CONNECTED) {
 		printf("Not connected to ECU\n");
 		return CMD_OK;
 	}
@@ -242,32 +231,26 @@ cmd_test_readiness(UNUSED(int argc), UNUSED(char **argv))
 			0x00, 0x00, 0x00, 0x00,
 			(void *)&_RQST_HANDLE_READINESS);
 
-	if ((rv < 0) || (find_ecu_msg(0, 0x41) == NULL))
-	{
+	if ((rv < 0) || (find_ecu_msg(0, 0x41) == NULL)) {
 		printf("Mode 1 PID 1 request failed\n");
 		return CMD_OK;
 	}
 
 	/* And process results */
-	for (i=0, ep=ecu_info; i<ecu_count; i++, ep++)
-	{
-		if (ep->mode1_data[1].type == TYPE_GOOD)
-		{
+	for (i=0, ep=ecu_info; i<ecu_count; i++, ep++) {
+		if (ep->mode1_data[1].type == TYPE_GOOD) {
 			int supported, value;
 
-			for (i=0; i<12; i++)
-			{
+			for (i=0; i<12; i++) {
 				text = test_names[i];
 				if (text == NULL)
 					continue;
-				if (i<4)
-				{
+				if (i<4) {
 					supported = (ep->mode1_data[1].data[3]>>i)&1;
 					value = (ep->mode1_data[1].data[3]>>(i+4))&1;
 
 				}
-				else
-				{
+				else {
 					supported = (ep->mode1_data[1].data[4]>>(i-4))&1;
 					value = (ep->mode1_data[1].data[5]>>(i-4))&1;
 				}

--- a/scantool/scantool_vag.c
+++ b/scantool/scantool_vag.c
@@ -36,8 +36,7 @@
 
 
 static int cmd_vag_help(int argc, char **argv);
-const struct cmd_tbl_entry vag_cmd_table[] =
-{
+const struct cmd_tbl_entry vag_cmd_table[] = {
 	{ "help", "help [command]", "Gives help for a command",
 		cmd_vag_help, 0, NULL},
 	{ "?", "? [command]", "Gives help for a command",
@@ -58,14 +57,12 @@ const struct cmd_tbl_entry vag_cmd_table[] =
 /*
  * Table of english descriptions of the VW ECU addresses
  */
-struct vw_id_info
-{
+struct vw_id_info {
 	const int id;
 	const char *command;
 } ;
 
-const struct vw_id_info vw_ids[] =
-{
+const struct vw_id_info vw_ids[] = {
 	{DIAG_VAG_ECU_ENGINE, "Engine" },
 	{DIAG_VAG_ECU_GEARBOX, "Gearbox" },
 	{DIAG_VAG_ECU_ABS, "ABS" },
@@ -75,7 +72,6 @@ const struct vw_id_info vw_ids[] =
 };
 
 static int
-cmd_vag_help(int argc, char **argv)
-{
+cmd_vag_help(int argc, char **argv) {
 	return help_common(argc, argv, vag_cmd_table);
 }

--- a/scantool/utlist.h
+++ b/scantool/utlist.h
@@ -287,10 +287,9 @@ do {                                                                            
 #define LL_COUNT(head,el,counter)                                                              \
     LL_COUNT2(head,el,counter,next)                                                            \
 
-#define LL_COUNT2(head,el,counter,next)                                                        \
-{                                                                                              \
+#define LL_COUNT2(head,el,counter,next) {                                                      \
     counter = 0;                                                                               \
-    LL_FOREACH2(head,el,next){ ++counter; }                                                    \
+    LL_FOREACH2(head,el,next) { ++counter; }                                                   \
 }
 
 #define LL_FOREACH(head,el)                                                                    \

--- a/scantool/utlist.h
+++ b/scantool/utlist.h
@@ -257,7 +257,7 @@ do {                                                                            
   if ((head) == (del)) {                                                                       \
     (head)=(head)->next;                                                                       \
   } else {                                                                                     \
-    char *_tmp = (char*)(head);                                                                \
+    char *_tmp = (char *)(head);                                                                \
     while ((head)->next && ((head)->next != (del))) {                                          \
       head = (head)->next;                                                                     \
     }                                                                                          \
@@ -265,7 +265,7 @@ do {                                                                            
       (head)->next = ((del)->next);                                                            \
     }                                                                                          \
     {                                                                                          \
-      char **_head_alias = (char**)&(head);                                                    \
+      char **_head_alias = (char **)&(head);                                                    \
       *_head_alias = _tmp;                                                                     \
     }                                                                                          \
   }                                                                                            \


### PR DESCRIPTION
These are some cosmetic changes which make scantool code use consistent "styles" of whitespace and newline usage.

I think mostly the styles you prefer were chosen, at least regarding the curly brackets; but keep in mind that any style is much prettier than the heterogeneous mix currently in existance (it is *very* irregular right now), so including any of these patches would be an improvement to human readability of code, in my opinion.