### PR TITLE
wait_enter: Make format string a constant

### DIFF
--- a/scantool/scantool_cli.c
+++ b/scantool/scantool_cli.c
@@ -946,7 +946,7 @@ int htoi(char *buf) {
  * Wait until ENTER is pressed
  */
 void wait_enter(const char *message) {
-	printf(message);
+	printf("%s", message);
 	while (1) {
 		int ch = getc(stdin);
 		if (ch == '\n')


### PR DESCRIPTION
This would have been the intended meaning, because wait enter only takes
the one string parameter.