### PR TITLE
Rename types with names reserved by POSIX

### DIFF
--- a/scantool/diag_l2.c
+++ b/scantool/diag_l2.c
@@ -49,14 +49,12 @@ int diag_l2_debug;
 
 
 /* struct to manage L2 stuff, used in here only */
-struct l2_internal_t {
-	diag_mtx *connlist_mtx;	//mutex for accessing dl2conn_list
-	struct diag_l2_conn	*dl2conn_list;	//linked-list of current diag_l2_conn's
-	struct diag_l2_link *dl2l_list;	//linked-list of current L2-L0 links
+static struct {
+	diag_mtx *connlist_mtx;            // mutex for accessing dl2conn_list
+	struct diag_l2_conn *dl2conn_list; // linked-list of current diag_l2_conn-s
+	struct diag_l2_link *dl2l_list;    // linked-list of current L2-L0 links
 	bool init_done;
-};
-
-static struct l2_internal_t l2internal = {0};
+} l2internal = {0};
 
 
 /** Find an existing L2 link using the specified L0 device.

--- a/scantool/scantool.c
+++ b/scantool/scantool.c
@@ -92,7 +92,7 @@ uint8_t	global_O2_sensors;	/* O2 sensors bit mask */
 /*
  * Data received from each ecu
  */
-ecu_data_t	ecu_info[MAX_ECU];
+ecu_data	ecu_info[MAX_ECU];
 unsigned int ecu_count;		/* How many ecus are active */
 
 
@@ -118,7 +118,7 @@ const int _RQST_HANDLE_READINESS = RQST_HANDLE_READINESS; 	//Readiness tests
 
 struct diag_msg *
 find_ecu_msg(int byte, databyte_type val) {
-	ecu_data_t *ep;
+	ecu_data *ep;
 	struct diag_msg *rxmsg = NULL;
 	unsigned int i;
 
@@ -161,7 +161,7 @@ j1979_data_rcv(void *handle, struct diag_msg *msg) {
 	struct diag_msg *tmsg;
 	unsigned int i;
 	int ihandle;
-	ecu_data_t	*ep;
+	ecu_data	*ep;
 
 	if (handle != NULL) {
 		ihandle= * (int *)handle;
@@ -479,7 +479,7 @@ l3_do_j1979_rqst(struct diag_l3_conn *d_conn, uint8_t mode, uint8_t p1, uint8_t 
 	uint8_t data[7];
 	int ihandle;
 	int rv;
-	ecu_data_t *ep;
+	ecu_data *ep;
 	unsigned int i;
 
 	uint8_t *rxdata;
@@ -841,7 +841,7 @@ do_j1979_getdata(int interruptible) {
 	unsigned int i,j;
 	int rv;
 	struct diag_l3_conn *d_conn;
-	ecu_data_t *ep;
+	ecu_data *ep;
 	struct diag_msg *msg;
 
 	d_conn = global_l3_conn;
@@ -934,7 +934,7 @@ do_j1979_getdata(int interruptible) {
  * This is the basic work horse routine
  */
 void do_j1979_basics() {
-	ecu_data_t *ep;
+	ecu_data *ep;
 	unsigned int i;
 	int o2monitoring = 0;
 
@@ -1089,7 +1089,7 @@ do_j1979_ncms(int printall) {
 	struct diag_l3_conn *d_conn;
 	unsigned int i, j;
 //	int supported=0;		//not used ?
-	ecu_data_t *ep;
+	ecu_data *ep;
 
 	uint8_t merged_mode6_info[0x100];
 
@@ -1146,7 +1146,7 @@ do_j1979_getmodeinfo(uint8_t mode, int response_offset) {
 	struct diag_l3_conn *d_conn;
 	int pid;
 	unsigned int i, j;
-	ecu_data_t *ep;
+	ecu_data *ep;
 	int not_done;
 	uint8_t *data;
 
@@ -1241,7 +1241,7 @@ do_j1979_getmodeinfo(uint8_t mode, int response_offset) {
  */
 void
 do_j1979_getpids() {
-	ecu_data_t *ep;
+	ecu_data *ep;
 	unsigned int i, j;
 
 	do_j1979_getmodeinfo(1, 2);
@@ -1333,7 +1333,7 @@ int
 do_j1979_getdtcs() {
 	int rv;
 	struct diag_l3_conn *d_conn;
-	ecu_data_t *ep;
+	ecu_data *ep;
 	unsigned int i;
 	int num_dtcs, readiness, mil;
 
@@ -1420,7 +1420,7 @@ do_j1979_getO2sensors() {
 	struct diag_l3_conn *d_conn;
 	unsigned int i, j;
 	int num_sensors;
-	ecu_data_t *ep;
+	ecu_data *ep;
 
 	d_conn = global_l3_conn;
 
@@ -1583,7 +1583,7 @@ static void do_usage (void) {
 
 
 static void format_o2(char *buf, int maxlen, UNUSED(int english),
-	const struct pid *p, response_t *data, int n) {
+	const struct pid *p, response *data, int n) {
 		double v = DATA_SCALED(p, DATA_1(p, n, data));
 		int t = DATA_1(p, n + 1, data);
 
@@ -1598,7 +1598,7 @@ static void format_o2(char *buf, int maxlen, UNUSED(int english),
 
 static void
 format_aux(char *buf, int maxlen, UNUSED(int english), const struct pid *p,
-	response_t *data, int n) {
+	response *data, int n) {
 		snprintf(buf, maxlen, (DATA_RAW(p, n, data) & 1) ? "PTO Active" : "----");
 }
 
@@ -1606,7 +1606,7 @@ format_aux(char *buf, int maxlen, UNUSED(int english), const struct pid *p,
 
 static void
 format_fuel(char *buf, int maxlen, UNUSED(int english), const struct pid *p,
-	response_t *data, int n) {
+	response *data, int n) {
 		int s = DATA_1(p, n, data);
 
 		switch (s) {
@@ -1635,7 +1635,7 @@ format_fuel(char *buf, int maxlen, UNUSED(int english), const struct pid *p,
 
 
 static void
-format_data(char *buf, int maxlen, int english, const struct pid *p, response_t *data, int n) {
+format_data(char *buf, int maxlen, int english, const struct pid *p, response *data, int n) {
 		double v;
 
 		v = DATA_SCALED(p, DATA_RAW(p, n, data));

--- a/scantool/scantool.h
+++ b/scantool/scantool.h
@@ -41,12 +41,12 @@ extern "C" {
 
 
 /* Structure to hold responses */
-typedef struct response {
+typedef struct {
 	uint8_t	type;
 	uint8_t	len;
 	uint8_t	data[7];
 
-} response_t;
+} response;
 
 #define TYPE_UNTESTED	0	/* unchecked, prob because ECU doesn't support */
 #define TYPE_FAILED	1	/* Got failure response */
@@ -57,7 +57,7 @@ typedef struct response {
  * - one request can result in more than one ECU responding, and so
  * the data is stored in this
  */
-typedef struct ecu_data {
+typedef struct {
 	uint8_t 	valid;		/* Valid flag */
 	uint8_t	ecu_addr;	/* Address */
 
@@ -74,11 +74,11 @@ typedef struct ecu_data {
 
 	uint8_t	O2_sensors;	/* O2 sensors bit mask */
 
-	response_t	mode1_data[256]; /* Response data for all responses */
-	response_t	mode2_data[256]; /* Same, but for freeze frame */
+	response	mode1_data[256]; /* Response data for all responses */
+	response	mode2_data[256]; /* Same, but for freeze frame */
 
 	struct diag_msg	*rxmsg;		/* Received message */
-} ecu_data_t;
+} ecu_data;
 
 #define ECU_DATA_PIDS	0x01
 #define ECU_DATA_MODE2	0x02
@@ -88,7 +88,7 @@ typedef struct ecu_data {
 #define ECU_DATA_MODE9	0x20
 
 #define MAX_ECU 8			/* Max 8 Ecus responding */
-extern ecu_data_t	ecu_info[MAX_ECU];
+extern ecu_data	ecu_info[MAX_ECU];
 extern unsigned int ecu_count;
 
 struct diag_l2_conn;
@@ -159,7 +159,7 @@ void	l2raw_data_rcv(void *handle, struct diag_msg *msg);
 /** J1979 PID structures + utils **/
 struct pid ;
 /* format <numbytes> bytes of data into buf, up to <maxlen> chars. */
-typedef void (formatter)(char *buf, int maxlen, int units, const struct pid *, response_t *, int numbytes);
+typedef void (formatter)(char *buf, int maxlen, int units, const struct pid *, response *, int numbytes);
 
 struct pid {
 	int pidID ;

--- a/scantool/scantool_aif.c
+++ b/scantool/scantool_aif.c
@@ -94,7 +94,7 @@ static void aif_monitor (UNUSED(void *data)) {
 
 			for (j = 0 ; get_pid(j) != NULL ; j++) {
 				const struct pid *p = get_pid(j) ;
-				ecu_data_t   *ep ;
+				ecu_data   *ep ;
 				char buf[24] ;
 
 				for (i = 0, ep = ecu_info ; i < ecu_count ; i++, ep++) {

--- a/scantool/scantool_cli.h
+++ b/scantool/scantool_cli.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-typedef struct cmd_tbl_entry {
+struct cmd_tbl_entry {
 	const char *command;		/* Command name */
 	const char *usage;		/* Usage info */
 	const char *help;		/* Help Text */
@@ -42,7 +42,7 @@ typedef struct cmd_tbl_entry {
 
 	const struct cmd_tbl_entry *sub_cmd_tbl;		/* Next layer */
 
-} cmd_tbl_entry_t ;
+};
 
 /* Return values from the commands */
 #define CMD_OK		0	/* OK */

--- a/scantool/scantool_dyno.c
+++ b/scantool/scantool_dyno.c
@@ -130,7 +130,7 @@ static int cmd_dyno_mass(int argc, char **argv) {
 
 /* measure speed */
 // return <0 if error
-static int measure_data(uint8_t data_pid, ecu_data_t *ep) {
+static int measure_data(uint8_t data_pid, ecu_data *ep) {
 	int rv;
 
 	if (global_l3_conn == NULL) {
@@ -276,7 +276,7 @@ int dyno_loss_done;
  */
 
 static int cmd_dyno_loss(UNUSED(int argc), UNUSED(char **argv)) {
-	ecu_data_t *ep;
+	ecu_data *ep;
 
 	int speed;              /* measured speed */
 	int speed_previous = 0; /* previous speed */
@@ -422,7 +422,7 @@ static int cmd_dyno_setloss(int argc, char **argv) {
  */
 
 static int cmd_dyno_run(UNUSED(int argc), UNUSED(char **argv)) {
-	ecu_data_t *ep;
+	ecu_data *ep;
 
 	int speed;						/* measured speed */
 	int rpm;							/* measured rpm */

--- a/scantool/scantool_obd.c
+++ b/scantool/scantool_obd.c
@@ -166,7 +166,7 @@ cmd_watch(int argc, char **argv) {
 static void
 print_current_data(bool english) {
 	char buf[24];
-	ecu_data_t *ep;
+	ecu_data *ep;
 	unsigned int i;
 	unsigned int j;
 
@@ -204,7 +204,7 @@ print_current_data(bool english) {
 }
 
 static void
-log_response(int ecu, response_t *r) {
+log_response(int ecu, response *r) {
 	assert(global_logfp != NULL);
 
 	/* Only print good records */
@@ -219,8 +219,8 @@ log_response(int ecu, response_t *r) {
 
 static void
 log_current_data(void) {
-	response_t *r;
-	ecu_data_t *ep;
+	response *r;
+	ecu_data *ep;
 	unsigned int i;
 
 	if (!global_logfp) {
@@ -389,7 +389,7 @@ cmd_cleardtc(UNUSED(int argc), UNUSED(char **argv)) {
 
 static int
 cmd_ecus(UNUSED(int argc), UNUSED(char **argv)) {
-	ecu_data_t *ep;
+	ecu_data *ep;
 	unsigned int i;
 
 	if (global_state < STATE_SCANDONE) {
@@ -411,7 +411,7 @@ cmd_ecus(UNUSED(int argc), UNUSED(char **argv)) {
 }
 
 static void
-print_resp_info(UNUSED(int mode), response_t *data) {
+print_resp_info(UNUSED(int mode), response *data) {
 
 	int i;
 	for (i=0; i<256; i++) {
@@ -432,7 +432,7 @@ print_resp_info(UNUSED(int mode), response_t *data) {
 
 static int
 cmd_dumpdata(UNUSED(int argc), UNUSED(char **argv)) {
-	ecu_data_t *ep;
+	ecu_data *ep;
 	int i;
 
 	printf("Current Data\n");
@@ -481,7 +481,7 @@ print_pidinfo(int mode, uint8_t *pid_data) {
 
 
 static int cmd_pids(UNUSED(int argc), UNUSED(char **argv)) {
-	ecu_data_t *ep;
+	ecu_data *ep;
 	int i;
 
 	if (global_state < STATE_SCANDONE) {

--- a/scantool/scantool_test.c
+++ b/scantool/scantool_test.c
@@ -124,7 +124,7 @@ cmd_test_rvi(UNUSED(int argc), UNUSED(char **argv)) {
 
 	d_conn = global_l3_conn;
 
-	ecu_data_t *ep;
+	ecu_data *ep;
 	unsigned i;
 	bool merged_mode9_info[0x100];
 	#define MODE9_INFO_MAXLEN 0x100
@@ -200,7 +200,7 @@ static int
 cmd_test_readiness(UNUSED(int argc), UNUSED(char **argv)) {
 	int rv;
 	struct diag_l3_conn *d_conn;
-	ecu_data_t *ep;
+	ecu_data *ep;
 	unsigned int i;
 	const char *text;
 


### PR DESCRIPTION
l2_internal_t, ecu_data_t, response_t, and cmd_tbl_entry_t are illegal
to define locally for POSIX applications because the standard reserves
all names with the suffix.