### PR TITLE
Added Windows trick with timeBeginPeriod() to increase Sleep() accuracy

### DIFF
--- a/scantool/CMakeLists.txt
+++ b/scantool/CMakeLists.txt
@@ -86,6 +86,9 @@ if (NOT WIN32)
 	#link to libmath (m); not required on win32 (msvcrt provides sin() etc)
 	#link to pthread (win* uses native API)
 	target_link_libraries(diag m ${CMAKE_THREAD_LIBS_INIT})
+else()
+	# if WIN32 then use winmm lib and timeBeginPeriod() to increase Sleep() accuracy under Windows
+	target_link_libraries(diag winmm)
 endif ()
 
 #if required, link with -lrt (see top-level CMakeLists.txt)


### PR DESCRIPTION
Mainly on Windows 10 based-laptops and Windows 7 machines working from battery there was a huge spread value during initial timing calibration using diag_os_calibrate() causing instability and even inability to connect to ECU.
On RomRaider forums there was a workaround suggested to run in background media player software.
After some research it comes out that in this case Windows timer period is changed, from default 15.6 ms value to the smallest possible (0.5 ms in my case). This allows to have timing errors close to zero, my tests shown avgerr variable values of 0..120 instead 1200..8000 without this tweak.
Same timer period change was added to diag_os_win.c as a part of diagnostics initialization.
Hope this will make it simpler for some of users :-)