### PR TITLE
Build sources with native Windows compilers.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
 build/*
+out/*
 .git/*
+.vscode/*
+.vs/*
+.idea/*
+CMakeSettings.json
+CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
-build/*
+build/
+out/*
+.vscode/
+.vs/
+.idea/
+CMakeSettings.json
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,27 @@
 
 cmake_minimum_required(VERSION 3.0.2)
 
+#
+# The following policies introduced in CMake 3.15 are needed to work 
+# around a flaw in the Visual Studio CMake integration. The used 
+# toolchain and platform definitions define /W3 and /MD (Release) 
+# respectively /MDd (Debug) by default during the compiler 
+# determination process.
+# If the warning level or the C runtime option are changed afterwards
+# these new options will not replace the already set ones but will be
+# added additionally. This leads to compiler warning D9025 (overriding
+# command line options) which can not be suppressed. These policies 
+# prevent the warning flags and runtime option set by default.
+#
+#  CMP0092 - warnings (https://cmake.org/cmake/help/v3.15/policy/CMP0092.html)
+#  CMP0091 - runtime  (https://cmake.org/cmake/help/v3.15/policy/CMP0091.html)
+#
+if (POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif ()
+if (POLICY CMP0092)
+  cmake_policy(SET CMP0092 NEW)
+endif ()
 
 project(freediag)
 
@@ -18,6 +39,7 @@ message("Using install prefix : ${CMAKE_INSTALL_PREFIX}")
 
 include (CheckLibraryExists)
 include (CheckFunctionExists)
+include (CheckSymbolExists)
 include (CheckTypeSize)
 include (CMakeDependentOption)
 include (GNUInstallDirs)
@@ -47,7 +69,33 @@ if (CMAKE_COMPILER_IS_GNUCC)
 	set (CMAKE_C_FLAGS_RELEASE "-DNDEBUG")
 	set (CMAKE_C_FLAGS_RELWITHDEBINFO "-gsplit-dwarf")
 	add_compile_options(-Wall -Wextra -Wformat -pedantic -std=gnu99 -Wstrict-prototypes -Wsign-compare)
-	add_compile_options(-Wredundant-decls -Wformat-overflow)
+	add_compile_options(-Wredundant-decls)
+elseif (CMAKE_BASE_NAME STREQUAL "bcc32c")
+	#set all warnings as errors for Embarcadero clang based borland compiler.
+	add_compile_options("-w!")
+	#add static C runtime.
+	link_libraries("cw32mt")	
+elseif (CMAKE_BASE_NAME STREQUAL "bcc32x")
+	#set all warnings as errors for Embarcadero clang based compiler.
+	add_compile_options("-Wall" "-Werror")
+	#add static C runtime.
+	link_libraries("cw32mt")
+elseif (CMAKE_BASE_NAME STREQUAL "bcc64")
+	#set all warnings as errors for Embarcadero clang based 64 bit compiler.
+	add_compile_options("-Wall" "-Werror")
+	#add static C runtime.
+	link_libraries("cw64mt")	
+elseif (MSVC)
+    # 1. Set the warning level to 2.
+	add_compile_options(/W2 /WX)
+	# 2. Clear the default content of CMAKE_MSVC_RUNTIME_LIBRARY
+	set(CMAKE_MSVC_RUNTIME_LIBRARY "")
+	# 3. Set the compiler options for the static multithreaded version.
+	add_compile_options($<$<CONFIG:>:/MT> $<$<CONFIG:Debug>:/MTd> $<$<CONFIG:Release>:/MT>)
+	if (MSVC_VERSION LESS 1920)
+		#require at least winXP
+		message(WARNING "Visual Studio version before 16 (2019) may not work ! Proceed at your risk !")
+	endif ()
 else ()
 	message(WARNING "non-gcc compiler, verify compiler options !")
 	#not sure what we should use on other compilers.
@@ -79,6 +127,22 @@ if(WIN32)
 		message(WARNING "At least Win XP is required ! Proceed at your risk !")
 	endif ()
 	set (PLATF "-win32")	#for package name string generation only.
+	#check for old Microsoft compliant kbhit() and getch() 
+	#exports in the C runtime.
+	check_symbol_exists (_kbhit "conio.h" HAVE_STD_KBHIT)
+	if (NOT HAVE_STD_KBHIT)
+	    check_symbol_exists (kbhit "conio.h" HAVE_MS_KBHIT)
+        if (NOT HAVE_MS_KBHIT)
+            message(FATAL_ERROR "neither _kbhit nor kbhit function present.")
+		endif ()
+	endif ()
+	check_symbol_exists (_getch "conio.h" HAVE_STD_GETCH)
+	if (NOT HAVE_STD_GETCH)
+	    check_symbol_exists (getch "conio.h" HAVE_MS_GETCH)
+        if (NOT HAVE_MS_GETCH)
+            message(FATAL_ERROR "neither _getch nor getch function present.")
+		endif ()
+	endif ()
 else()
 	check_function_exists (alarm HAVE_ALARM)
 	check_function_exists (select HAVE_SELECT)

--- a/build_simple.bat
+++ b/build_simple.bat
@@ -1,0 +1,18 @@
+@echo off
+REM
+REM Make sure cmake.exe and MinGW are in the PATH
+REM
+IF [%OS%]==[Windows_NT] SETLOCAL
+IF NOT EXIST build (
+   mkdir build
+)
+
+cd build || GOTO :ERROR
+cmake -G"MinGW Makefiles" ^
+	  -DBUILD_DIAGTEST=ON ^
+	  -DCMAKE_VERBOSE_MAKEFILE=0 ^
+	  -S .. || GOTO :ERROR
+cmd /k cmd /c mingw32-make
+
+:ERROR
+cmd /k 

--- a/build_simple.sh
+++ b/build_simple.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-
-## debian/ubuntu: 
+#
+## debian/ubuntu:
 ## sudo apt install build-essential cmake g++ make pkg-config libfltk1.3-dev
-
+#
 mkdir -p build
 cd build
-cmake ..
+cmake -G"Unix Makefiles" \
+      -DBUILD_DIAGTEST=ON \
+      -DCMAKE_VERBOSE_MAKEFILE=0 \
+      -S .. || exit 1
 make

--- a/cconf.h.in
+++ b/cconf.h.in
@@ -10,6 +10,8 @@
 
 #cmakedefine HAVE_GETTIMEOFDAY
 #cmakedefine HAVE_STRCASECMP
+#cmakedefine HAVE_MS_KBHIT
+#cmakedefine HAVE_MS_GETCH
 #cmakedefine HAVE_ALARM
 #cmakedefine HAVE_SELECT
 

--- a/scantool/diag.h
+++ b/scantool/diag.h
@@ -46,6 +46,13 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>		/* For uint8_t, etc. This is a C99 header */
+
+#if defined(_MSC_VER)
+	//silence warnings about non-portable "_s" function replacements. 
+	//this must be set before including <stdio.h>.
+	#define _CRT_SECURE_NO_WARNINGS	
+	#pragma warning(disable:4996)
+#endif /* _MSC_VER Visual Studio */ 
 #include <stdio.h>		/* For FILE */
 
 #include "diag_os.h"	//for mutexes...
@@ -56,13 +63,16 @@ extern "C" {
 #define FLFMT "%s:%d:  "		//for debug messages
 
 
-#ifndef HAVE_STRCASECMP	//strcasecmp is POSIX, but kernel32 provides lstrcmpi which should be equivalent.
-#ifdef WIN32
-	#define strcasecmp(a,b) lstrcmpi((LPCTSTR) a, (LPCTSTR) b)
-#else
-	#error Your system provides no strcasecmp ! This is a problem !
-#endif 	//WIN32
-#endif	//have_strcasecmp
+#ifdef HAVE_STRCASECMP
+	#include <strings.h> //for strcasecmp
+#else	
+	#ifdef WIN32 
+        //strcasecmp is POSIX, but kernel32 provides lstrcmpi which should be equivalent.
+		#define strcasecmp(a,b) lstrcmpi((LPCTSTR) a, (LPCTSTR) b)
+	#else
+		#error Your system provides no strcasecmp ! This is a problem !
+	#endif 	//WIN32
+#endif	//HAVE_STRCASECMP
 
 
 #define DB_FILE "./freediag_carsim_all.db"	//default simfile for CARSIM interface
@@ -77,24 +87,28 @@ extern "C" {
 #endif // __GNUC__
 
 //hacks for MS Visual studio / visual C
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 	typedef SSIZE_T ssize_t;	//XXX ssize_t is currently only needed because of diag_tty_unix.c:diag_tty_{read,write}.
-				//TODO : rework read/write types to use a combination of size_t and int ?
-	#define snprintf _snprintf	//danger : _snprintf doesn't guarantee zero-termination !?
-	#pragma message("Warning: MSVC _sprintf() may be dangerous !\
-					Please ask your compiler vendor to supply a C99-compliant snprintf()...")
-	//CURFILE will be defined by CMake on a per-file basis !
-	#pragma message("Warning: MSVC may not work with the CURFILE macro. See diag.h")
-	// apparently some (all ?) MSVC compilers don't support per-file defines, so CURFILE would be the
-	// same for all source files.
-	// The disadvantage of __FILE__ is that it often (always ?) holds the absolute path of the file,
-	// not just the filename. For our debugging messages we only care about the filename, hence CURFILE.
-	#define FL  __FILE__, __LINE__
-	#define _CRT_SECURE_NO_WARNINGS	//silence warnings about non-portable "_s" function replacements. Not going to happen
-	#pragma warning(disable:4996)	//same thing, apparently on some setups the above doesn't work.
+								//TODO : rework read/write types to use a combination of size_t and int ?
+	#if _MSC_VER < 1920 /* anything older than Visual Studio 2019 */
+		#define snprintf _snprintf	//danger : _snprintf doesn't guarantee zero-termination !?
+									//as of Visual Studio 2015 the snprintf function is c99 compatible.
+									//https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-160
+		#pragma message("Warning: MSVC _sprintf() may be dangerous ! Please ask your compiler vendor to supply a C99-compliant snprintf()...")
+		//CURFILE will be defined by CMake on a per-file basis !
+		#pragma message("Warning: MSVC may not work with the CURFILE macro. See diag.h")
+		// apparently some (all ?) MSVC compilers don't support per-file defines, so CURFILE would be the
+		// same for all source files.
+		// The disadvantage of __FILE__ is that it often (always ?) holds the absolute path of the file,
+		// not just the filename. For our debugging messages we only care about the filename, hence CURFILE.
+		#define FL  __FILE__, __LINE__
+	#else 
+		// Using Visual Studio 2019 and higher the CURFILE macro will work. 
+		#define FL CURFILE, __LINE__
+	#endif /* _MSC_VER < 1920  Visual Studio 2019 */
 #else
 	#define FL CURFILE, __LINE__
-#endif
+#endif /* _MSC_VER Visual Studio */ 
 /****** ******/
 
 /*

--- a/scantool/diag_l2.c
+++ b/scantool/diag_l2.c
@@ -57,7 +57,7 @@ static struct {
 } l2internal = {
 	.dl2conn_list = NULL,
 	.dl2l_list = NULL,	// linked-list of current L2-L0 links
-	.init_done = NULL
+	.init_done = false
 };
 
 

--- a/scantool/diag_os_win.c
+++ b/scantool/diag_os_win.c
@@ -32,7 +32,16 @@
 #include <process.h>
 #include <windows.h>
 #include <conio.h>	//for _kbhit, _getch
-#include <inttypes.h> 	//for PRIu64 formatters
+/** Check the _kbhit function **/
+#ifdef HAVE_MS_KBHIT
+#define _kbhit kbhit
+#endif
+/** Check the _getch function **/
+#ifdef HAVE_MS_GETCH
+#define _getch getch
+#endif
+
+#include <inttypes.h> //for PRIu64 formatters
 
 static bool diag_os_init_done=0;
 static bool timer_period_changed = 0;	//do we need to reset timeEndPeriod on exit

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -28,14 +28,13 @@
  * Extended diagnostics for '96-'98 Volvo 850, S40, C70, S70, V70, XC70 and V90
  *
  */
-
+ 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <ctype.h>
 #include <errno.h>
-
+ 
 #include "diag.h"
 #include "diag_l1.h"
 #include "diag_l2.h"


### PR DESCRIPTION
## Scope
Make the source tree compile with native Windows C compilers like Embarcaderos clang based bcc32c compiler and Microsoft Visual Studio 2019. These compiler are fully c99 compliant and available for free. Therefore it may be an alternative for example to MinGW on Windows system.

The changes to the build system (main `CMakeLists.txt` file) are compatible to cmake 3.0.2 even though the compiler support for the Embarcadero compiler will need cmake 3.6.0 to work properly. To get the best support for Microsoft Visual Studio 2019 it seem recommended to use a recent cmake version like 3.19.* (recent as of the creation of this PR) 

All changes are tested with a standard cmake 3.6.0 installation under linux using the default toolchain and on Windows using MinGW and the Embarcadero Free C++ Compiler 10.2  respectively Embarcadero C++ Builder Community Edition 10.3 (newer and commercial versions of RAD Studio/C++ Builder should work as well). Visual Studio 2019 ( version 16.8.4) was tested with cmake 3.19.3.

### What has changed?
#### Source Files:

`scantool_850.c`

- Removed include `<strings.h>` - this is a POSIX include so the Windows compiles don't have it. 
- The inclusion of `strings.h` was moved to `diag.h` (see below) where the Win32 specific handling for `strcasecmp` via the configuration define `HAVE_STRCASECMP` is already located.

`diag_os_win.c`

- The Embarcadero compiler (and older Borland compilers as well) do not define the `_kbhit()` function in `conio.h`. They have an inline definition for `_getch()` but traditionally the functions are only defined without the `_` (the old Microsoft style). This leads to an linker error for the `_kbhit` symbol.  To avoid this error I changed this source and the build system project (see below) to check for both definitions and use the non underscored version if the underscored version is not available. If under Windows none of the functions are detected the build system will raise a fatal error.

`diag_l2.c`

Change the initializer of the `l2internal` struct to remove a compiler waring under MSVC. The bool element `init_done` is now initialized with `false` instead of `NULL`.

`diag.h`

- On UNIX systems if  `HAVE_STRCASECMP` is set the header `strings.h` is now included.
- The special handling for Microsoft compilers was changed. Microsoft's current C Compiler (_MSC_VER >= 1920) fully supports ANSI C c99. The `snprintf ` function is c99 compatible  (https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-160) since Visual Studio 2015. The `CURFILE` macro is supported as well. So all this special treatments now only apply to versions before Visual Studio 20219. 
- The disabling for the MVSC compiler warning W4996 was move before the include of `stdio.h` to disable the warning effectively.

#### Build system:

`CMakeLists.txt`

- Added warning options for the Embarcadero Compiler - bcc32x (the clang based compiler using clang standard command line options) is here supported as well althought takes some tweaks to make cmake recognize this compiler correctly.
- Added the static C Runtime import library for the Embarcadero compilers. The default is to use the dynamic C Runtime dlls which must be present when running the binary. 
- Added support for Visual Studio 2019 including linking against the static C runtime libary. The default is to use the dynamic C Runtime dlls which must be present when running the binary. The warning level for MSVC was set to level 2 (/W2) which should be equivalent to the current warning level of gcc. To add all type conversion warning during the build the warning level must be raised to level 3 (/W3) for MSVC and '-Wconversion'  must be added for gcc (tested on MinGW).
- Added the symbol checks for the `conio.h`  functions (see above).

`cconf.h.in`

- Populate the new defines `HAVE_MS_KBHIT` and `HAVE_MS_GETCH`.

`build_simple.bat`

Simple build scripts for convenience like the existing `build_simple.sh`. This script can serve as a starting point for new developers to get a fist impression about the build system. 

`.gitignore`
`.dockerignore`

- cmake 1.19 introduces so called presets defined in a JSON format. User presets can be stored in a file called `CMakeUserPresets.json` in the source directory. I find this a nice feature to manage multiple build configurations. This user preferences should not be version controlled so I added the file to the ignore files.
- I added the `CMakeSettings.json` file as well because Visual Studio used this file to manage there available configurations.
- Added IntelliJ IDEA, Visual Studio Code and Visual Studio directories to the ignore files. 

Perhaps you like the changes and accept this merge request. 

Thanks!

@fenugrec @nsajko 