### PR TITLE
Run cppcheck in Windows and linux configuration successfully on the s…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #Note : this file is a work in progress,
 #some checks may still be missing
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.10)
 
 #
 # The following policies introduced in CMake 3.15 are needed to work

--- a/cconf.h.in
+++ b/cconf.h.in
@@ -23,12 +23,12 @@
 #define DIAG_TEST_PROGNAME "@DIAG_TEST_PROGNAME@"
 #define PROJECT_NAME "@PROJECT_NAME@"
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
     #define PACKAGE_VERSION_VALUE ${PKGVERSIONMAJOR_VALUE},${PKGVERSIONMINOR_VALUE},0,0
     #define PACKAGE_VERSION_STR "@PKGVERSION@\0"
     #define PROJECT_NAME_STR "@PROJECT_NAME@\0" 
     #define SCANTOOL_PROGNAME_EXE "@SCANTOOL_PROGNAME@.exe\0"
     #define DIAG_TEST_PROGNAME_EXE "@DIAG_TEST_PROGNAME@.exe\0"
-#endif //_WIN32
+#endif //Windows
 
 #endif //ifndef _cconf_h

--- a/cmake/Windows-Embarcadero.cmake
+++ b/cmake/Windows-Embarcadero.cmake
@@ -1,0 +1,255 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+set(_EMBT_CPP_PREPROCESSOR "cpp32")
+set(EMBT_TARGET Windows)
+
+if(CMAKE_BASE_NAME STREQUAL "bcc32x")
+  set(BCC32X TRUE)
+  set(_EMBT_CPP_PREPROCESSOR "cpp32x")
+  set(CLANG_BASED TRUE)
+endif()
+
+if(CMAKE_BASE_NAME STREQUAL "bcc64")
+  set(BCC64 TRUE)
+  set(_EMBT_CPP_PREPROCESSOR "cpp64")
+  set(CLANG_BASED TRUE)
+  set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
+  set(CMAKE_IMPORT_LIBRARY_SUFFIX ".a")
+  set(CMAKE_LINK_LIBRARY_SUFFIX ".a")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+endif()
+
+if(CMAKE_BASE_NAME STREQUAL "bcc32c")
+  set(BCC32C TRUE)
+  set(_EMBT_CPP_PREPROCESSOR "cpp32c")
+endif()
+
+# This module is shared by multiple languages; use include blocker.
+if(__WINDOWS_EMBARCADERO)
+  return()
+endif()
+
+set(__WINDOWS_EMBARCADERO 1)
+set(BORLAND 1)
+
+if("${CMAKE_${_lang}_COMPILER_VERSION}" VERSION_LESS 6.30)
+  # Borland target type flags (bcc32 -h -t):
+  set(_tW "-tW")       # -tW  GUI App         (implies -U__CONSOLE__)
+  set(_tC "-tWC")      # -tWC Console App     (implies -D__CONSOLE__=1)
+  set(_tD "-tWD")      # -tWD Build a DLL     (implies -D__DLL__=1 -D_DLL=1)
+  set(_tM "-tWM")      # -tWM Enable threads  (implies -D__MT__=1 -D_MT=1)
+  set(_tR "-tWR -tW-") # -tWR Use DLL runtime (implies -D_RTLDLL, and '-tW' too!!)
+  # Notes:
+  #  - The flags affect linking so we pass them to the linker.
+  #  - The flags affect preprocessing so we pass them to the compiler.
+  #  - Since '-tWR' implies '-tW' we use '-tWR -tW-' instead.
+  #  - Since '-tW-' disables '-tWD' we use '-tWR -tW- -tWD' for DLLs.
+else()
+  set(EMBARCADERO 1)
+  set(_tC "-tC") # Target is a console application
+  set(_tD "-tD") # Target is a shared library
+  set(_tM "-tM") # Target is multi-threaded
+  set(_tR "-tR") # Target uses the dynamic RTL
+  set(_tW "-tW") # Target is a Windows application
+  set(_tV "-tV") # Target is a VCL application
+  set(_tJ "-tJ") # Target uses the Delphi Runtime
+  set(_tF "-tF") # Target is a FMX application
+  set(_tP "-tP") # Target creates a Package
+  set(_tU "-tU") # Target creates a Unicode
+endif()
+
+# if build type is not provided set it to debug mode
+if(NOT CMAKE_BUILD_TYPE)
+  set (CMAKE_BUILD_TYPE DEBUG CACHE STRING "Choose the type of build, options are: DEBUG RELEASE RELWITHDEBINFO MINSIZEREL.")
+endif()
+
+find_path(BIN_DIR_PATH NAMES ${CMAKE_BASE_NAME}.exe)
+get_filename_component(ROOTDIR ${BIN_DIR_PATH} PATH)
+  
+include_directories(SYSTEM "${ROOTDIR}/include/windows/crtl")
+include_directories(SYSTEM "${ROOTDIR}/include/windows/sdk")
+include_directories(SYSTEM "${ROOTDIR}/include/windows/rtl")
+include_directories(SYSTEM "${ROOTDIR}/include/dinkumware64")
+
+if(BCC32X OR BCC32C)
+  if(CMAKE_BUILD_TYPE MATCHES ".*DEB.*")
+    set(linker_Path1 "${ROOTDIR}/lib/win32c/debug")
+    set(linker_Path2 "${ROOTDIR}/lib/win32/debug")
+    set(linker_Path3 "${ROOTDIR}/lib/win32/debug/psdk")
+    set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path1}\"")
+    set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path2}\"")
+    set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path3}\"")
+  endif()
+  set(linker_Path1 "${ROOTDIR}/lib/win32c/release")
+  set(linker_Path2 "${ROOTDIR}/lib/win32/release")
+  set(linker_Path3 "${ROOTDIR}/lib/win32/release/psdk")
+  set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path1}\"")
+  set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path2}\"")
+  set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path3}\"")
+endif()
+  
+if(CLANG_BASED)
+  
+  if(BCC32X)
+    set(CMAKE_C_COMPILER ${ROOTDIR}/bin/bcc32x.exe)
+    set(CMAKE_CXX_COMPILER ${ROOTDIR}/bin/bcc32x.exe)
+  endif()
+  
+  if(BCC64)
+    if(CMAKE_BUILD_TYPE MATCHES ".*DEB.*")
+      set(linker_Path1 "${ROOTDIR}/lib/win64/debug")
+      set(linker_Path2 "${ROOTDIR}/lib/win64/debug/psdk")
+      set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path1}\"")
+      set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path2}\"")
+    endif()
+    set(linker_Path1 "${ROOTDIR}/lib/win64/release")
+    set(linker_Path2 "${ROOTDIR}/lib/win64/release/psdk")
+    set(CMAKE_C_COMPILER ${ROOTDIR}/bin/bcc64.exe)
+    set(CMAKE_CXX_COMPILER ${ROOTDIR}/bin/bcc64.exe)
+    set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path1}\"")
+    set(windows_LIBRARY "${windows_LIBRARY} -L \"${linker_Path2}\"")
+  endif()
+  
+  # Setting the Link Library Path in flag
+  set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS ${windows_LIBRARY})
+  set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS ${windows_LIBRARY})
+  # setting the link library flag
+  set(link_flags ${windows_LIBRARY})
+  set(CMAKE_EXE_LINKER_FLAGS ${link_flags} CACHE INTERNAL "exe link flags")
+  set(CMAKE_MODULE_LINKER_FLAGS ${link_flags} CACHE INTERNAL "module link flags")
+  set(CMAKE_SHARED_LINKER_FLAGS ${link_flags} CACHE INTERNAL "shared lnk flags")
+endif()
+
+set(_COMPILE_C "-c")
+set(_COMPILE_CXX "-P -c")
+set(CMAKE_LIBRARY_PATH_FLAG "-L")
+set(CMAKE_LINK_LIBRARY_FLAG "")
+set(CMAKE_FIND_LIBRARY_SUFFIXES "-bcc.lib" ".lib")
+
+# uncomment these out to debug makefiles
+#set(CMAKE_START_TEMP_FILE "")
+#set(CMAKE_END_TEMP_FILE "")
+#set(CMAKE_VERBOSE_MAKEFILE 1)
+    
+# Borland cannot handle + in the file name, so mangle object file name
+set (CMAKE_MANGLE_OBJECT_FILE_NAMES "ON")
+    
+# extra flags for a win32 exe
+set(CMAKE_CREATE_WIN32_EXE "${_tW}" )
+# extra flags for a console app
+set(CMAKE_CREATE_CONSOLE_EXE "${_tC}" )
+
+foreach(t EXE SHARED MODULE)
+  string(APPEND CMAKE_${t}_LINKER_FLAGS_INIT " ${_tM} -lS:1048576 -lSc:4098 -lH:1048576 -lHc:8192 ")
+  string(APPEND CMAKE_${t}_LINKER_FLAGS_DEBUG_INIT " -v")
+  string(APPEND CMAKE_${t}_LINKER_FLAGS_RELWITHDEBINFO_INIT " -v")
+endforeach()
+
+# The Borland link tool does not support multiple concurrent
+# invocations within a single working directory.
+if(NOT DEFINED CMAKE_JOB_POOL_LINK)
+  set(CMAKE_JOB_POOL_LINK BCC32LinkPool)
+  get_property(_bccjp GLOBAL PROPERTY JOB_POOLS)
+  if(NOT _bccjp MATCHES "BCC32LinkPool=")
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS BCC32LinkPool=1)
+  endif()
+  unset(_bccjp)
+endif()
+
+macro(__embarcadero_language lang)
+  set(CMAKE_${lang}_COMPILE_OPTIONS_DLL "${_tD}" ) # Note: This variable is a ';' separated list
+  set(CMAKE_SHARED_LIBRARY_${lang}_FLAGS "${_tD}") # ... while this is a space separated string.
+  set(CMAKE_${lang}_USE_RESPONSE_FILE_FOR_INCLUDES 1)
+
+  # compile a source file into an object file
+  # place <DEFINES> outside the response file because Borland refuses
+  # to parse quotes from the response file.
+  set(CMAKE_${lang}_COMPILE_OBJECT
+    "<CMAKE_${lang}_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o<OBJECT> ${_COMPILE_${lang}} <SOURCE>"
+    )
+
+  if(CLANG_BASED)
+     set(CMAKE_${lang}_LINK_EXECUTABLE
+         "<CMAKE_${lang}_COMPILER> -o<TARGET> <LINK_FLAGS> <FLAGS> ${CMAKE_START_TEMP_FILE} <LINK_LIBRARIES> <OBJECTS>${CMAKE_END_TEMP_FILE}"
+     )
+  else()
+    set(CMAKE_${lang}_LINK_EXECUTABLE
+        "<CMAKE_${lang}_COMPILER> -e<TARGET> <LINK_FLAGS> <FLAGS> ${CMAKE_START_TEMP_FILE} <LINK_LIBRARIES> <OBJECTS>${CMAKE_END_TEMP_FILE}"
+    )
+  endif ()
+
+  # place <DEFINES> outside the response file because Borland refuses
+  # to parse quotes from the response file.
+  set(CMAKE_${lang}_CREATE_PREPROCESSED_SOURCE
+    "${_EMBT_CPP_PREPROCESSOR} <DEFINES> <INCLUDES> <FLAGS> -o<PREPROCESSED_SOURCE> ${_COMPILE_${lang}} <SOURCE>"
+    )
+
+  # Create a module library.
+  set(CMAKE_${lang}_CREATE_SHARED_MODULE
+    "<CMAKE_${lang}_COMPILER> ${_tD} ${CMAKE_START_TEMP_FILE}-o<TARGET> <LINK_FLAGS> <LINK_LIBRARIES> <OBJECTS>${CMAKE_END_TEMP_FILE}"
+    )
+
+  # Create an import library for another target.
+  set(CMAKE_${lang}_CREATE_IMPORT_LIBRARY
+    "implib -c -w <TARGET_IMPLIB> <TARGET>"
+    )
+
+  # Create a shared library.
+  # First create a module and then its import library.
+  set(CMAKE_${lang}_CREATE_SHARED_LIBRARY
+    ${CMAKE_${lang}_CREATE_SHARED_MODULE}
+    ${CMAKE_${lang}_CREATE_IMPORT_LIBRARY}
+    )
+
+  # create a static library
+  if(BCC64)
+    set(CMAKE_${lang}_CREATE_STATIC_LIBRARY
+      "tlib64 ${CMAKE_START_TEMP_FILE}/p2048 <LINK_FLAGS> /a <TARGET_QUOTED> <OBJECTS>${CMAKE_END_TEMP_FILE}"
+      )
+  else()
+    set(CMAKE_${lang}_CREATE_STATIC_LIBRARY
+      "tlib ${CMAKE_START_TEMP_FILE}/p512 <LINK_FLAGS> /a <TARGET_QUOTED> <OBJECTS>${CMAKE_END_TEMP_FILE}"
+      )
+  endif()
+  
+
+  # Initial configuration flags.
+  string(APPEND CMAKE_${lang}_FLAGS_INIT " ${_tM}")
+
+  if(CLANG_BASED)
+    set(CMAKE_INCLUDE_SYSTEM_FLAG_${lang} "-isystem ")
+    string(APPEND CMAKE_${lang}_FLAGS_DEBUG_INIT " -O0 -g")  
+    string(APPEND CMAKE_${lang}_FLAGS_MINSIZEREL_INIT " -O1 -DNDEBUG")
+    string(APPEND CMAKE_${lang}_FLAGS_RELEASE_INIT " -O2 -DNDEBUG")
+    string(APPEND CMAKE_${lang}_FLAGS_RELWITHDEBINFO_INIT " -O3")
+  else()
+    string(APPEND CMAKE_${lang}_FLAGS_DEBUG_INIT " -Od -v")
+    string(APPEND CMAKE_${lang}_FLAGS_MINSIZEREL_INIT " -O1 -DNDEBUG")
+    string(APPEND CMAKE_${lang}_FLAGS_RELEASE_INIT " -O2 -DNDEBUG")
+    string(APPEND CMAKE_${lang}_FLAGS_RELWITHDEBINFO_INIT " -Od")
+    set(CMAKE_${lang}_STANDARD_LIBRARIES_INIT "import32.lib")
+  endif()
+endmacro()
+
+macro(set_embt_target)
+  foreach(arg IN ITEMS ${ARGN})
+    if(${arg} STREQUAL "FMX")
+      set(CMAKE_${_lang}_FLAGS "${CMAKE_${_lang}_FLAGS} ${_tF}")
+      include_directories(SYSTEM "${ROOTDIR}/include/windows/fmx")
+    elseif(${arg} STREQUAL "VCL")
+      set(CMAKE_${_lang}_FLAGS "${CMAKE_${_lang}_FLAGS} ${_tV}")
+      include_directories(SYSTEM "${ROOTDIR}/include/windows/vcl")
+    elseif(${arg} STREQUAL "DR")
+      set(CMAKE_${_lang}_FLAGS "${CMAKE_${_lang}_FLAGS} ${_tJ}")
+    elseif(${arg} STREQUAL "DynamicRuntime")
+      set(CMAKE_${_lang}_FLAGS "${CMAKE_${_lang}_FLAGS} ${_tR}")
+    elseif(${arg} STREQUAL "Package")
+      set(CMAKE_${_lang}_FLAGS "${CMAKE_${_lang}_FLAGS} ${_tP}")
+    elseif(${arg} STREQUAL "Unicode")
+      set(CMAKE_${_lang}_FLAGS "${CMAKE_${_lang}_FLAGS} ${_tU}")
+    else()
+      message("Error in set_embt_target: unknown target specified \"${arg}\"")
+    endif()
+  endforeach()
+endmacro()

--- a/cppcheck/linux.cppcheck
+++ b/cppcheck/linux.cppcheck
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="1">
+    <platform>unix32</platform>
+    <analyze-all-vs-configs>false</analyze-all-vs-configs>
+    <check-headers>true</check-headers>
+    <check-unused-templates>true</check-unused-templates>
+    <max-ctu-depth>2</max-ctu-depth>
+    <max-template-recursion>100</max-template-recursion>
+    <defines>
+        <define name="__unix__"/>
+        <define name="HAVE_STRCASECMP"/>
+		<define name="HAVE_GETTIMEOFDAY"/>
+		<define name="USE_INIFILE"/>
+    </defines>
+    <paths>
+        <dir name="../scantool/"/>
+		<dir name="../schedSetter/unix"/>
+    </paths>
+	<exclude>
+	    <path name="scantool/diag_os_win.h"/> 
+        <path name="scantool/diag_os_win.c"/>
+		<path name="scantool/diag_tty_win.h"/>
+        <path name="scantool/diag_tty_win.c"/>
+    </exclude>	
+    <suppressions>
+        <suppression>variableScope</suppression>
+		<suppression>unsignedLessThanZero</suppression>
+    </suppressions>
+</project>

--- a/cppcheck/run-cppcheck.bat
+++ b/cppcheck/run-cppcheck.bat
@@ -1,0 +1,37 @@
+@ECHO off
+REM -----------------------------------------
+SETLOCAL enableDelayedExpansion
+REM -----------------------------------------
+
+REM -----------------------------------------
+SET __EXIT_CODE=0
+
+REM -----------------------------------------
+WHERE cppcheck.exe > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 (
+   ECHO cppcheck.exe not found.
+   EXIT /B 1	
+)
+
+FOR /R . %%F IN (*.cppcheck) DO (
+	echo %%F
+	cppcheck ^
+	--enable=warning ^
+	--enable=style ^
+	--enable=performance ^
+	--enable=information ^
+	--suppress=missingInclude ^
+	--suppress=missingSystemInclude ^
+	--suppress=unmatchedSuppression ^
+	--error-exitcode=1 ^
+	--inline-suppr ^
+	"--project=%%F" > NUL || GOTO ERROR 
+)
+
+REM -----------------------------------------
+:ERROR
+set __EXIT_CODE=1
+
+REM -----------------------------------------
+EXIT /B %__EXIT_CODE%
+REM -----------------------------------------

--- a/cppcheck/win32.cppcheck
+++ b/cppcheck/win32.cppcheck
@@ -1,20 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="1">
-    <builddir>cppcheck_proj-cppcheck-build-dir</builddir>
-    <platform>unknown</platform>
+    <platform>win32A</platform>
     <analyze-all-vs-configs>false</analyze-all-vs-configs>
     <check-headers>true</check-headers>
     <check-unused-templates>true</check-unused-templates>
     <max-ctu-depth>2</max-ctu-depth>
     <max-template-recursion>100</max-template-recursion>
     <defines>
-        <define name="__unix__"/>
-        <define name="HAVE_STRCASECMP"/>
+        <define name="_WIN32"/>
+		<define name="USE_INIFILE"/>
     </defines>
     <paths>
-        <dir name="scantool"/>
+        <dir name="../scantool/"/>
     </paths>
+    <exclude>
+	    <path name="scantool/diag_os_unix.h"/> 
+        <path name="scantool/diag_os_unix.c"/>
+		<path name="scantool/diag_tty_unix.h"/>
+        <path name="scantool/diag_tty_unix.c"/>
+    </exclude>
     <suppressions>
         <suppression>variableScope</suppression>
+        <suppression>unsignedLessThanZero</suppression>
     </suppressions>
 </project>

--- a/scantool/CMakeLists.txt
+++ b/scantool/CMakeLists.txt
@@ -23,6 +23,45 @@ foreach (L2NAME IN LISTS L2LIST)
 	endif()
 endforeach()
 
+#integrate cppcheck checks if the binary is present.
+find_program (CPPCHECK_BIN NAMES cppcheck)
+if (NOT (CPPCHECK_BIN MATCHES "NOTFOUND"))
+       # cppcheck is found in the path so use it.
+       find_program (CMAKE_C_CPPCHECK NAMES cppcheck)
+       list (
+        APPEND CMAKE_C_CPPCHECK 
+            "--enable=warning"
+			"--enable=style"
+			"--enable=performance"
+			"--enable=information"
+            "--suppress=missingInclude"
+			"--suppress=missingSystemInclude"
+			"--suppress=unmatchedSuppression"
+			"--suppress=variableScope"
+			"--suppress=unsignedLessThanZero"
+            "--error-exitcode=1" 
+            "--inline-suppr"
+       )
+	   if (WIN32) 
+	      list (
+             APPEND CMAKE_C_CPPCHECK 
+             "--platform=win32A"
+			 "-D_WIN32"
+			 #
+			 # This is to prevent cppcheck to include windows.h.
+			 # The header leads to problems with the borland compilers.
+			 #  
+			 "-D_WINDOWS_"
+		  )
+	   else ()
+	      list (
+		     APPEND CMAKE_C_CPPCHECK 
+		     "--platform=unix32"
+		     "-D__unix__"
+	      )
+	   endif ()
+endif ()
+
 #and now generate diag_config.c ! (output in the build directory)
 configure_file ( diag_config.c.in diag_config.c)
 

--- a/scantool/diag.h
+++ b/scantool/diag.h
@@ -33,7 +33,7 @@ extern "C" {
 
 #include "cconf.h"
 
-#ifdef WIN32
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 	#ifndef _WIN32_WINNT
 		#define _WIN32_WINNT 0x0500	//use > winXP features...
 	#endif
@@ -66,7 +66,7 @@ extern "C" {
 #ifdef HAVE_STRCASECMP
 	#include <strings.h>
 #else
-	#ifdef WIN32
+	#ifdef _WIN32
         //strcasecmp is POSIX, but kernel32 provides lstrcmpi which should be equivalent.
 		#define strcasecmp(a,b) lstrcmpi((LPCTSTR) a, (LPCTSTR) b)
 	#else

--- a/scantool/diag_cfg.c
+++ b/scantool/diag_cfg.c
@@ -125,7 +125,7 @@ int diag_cfg_setopt(struct cfgi *cfgp, int optid) {
 //for u8 / int types, sprintf with %X and %d formatters respectively
 char *diag_cfg_getstr(struct cfgi *cfgp) {
 	char *str;
-	size_t len;
+	size_t len = 0;
 	int rv;
 
 	/* determine required length first */

--- a/scantool/diag_l2_iso14230.c
+++ b/scantool/diag_l2_iso14230.c
@@ -1067,12 +1067,12 @@ dl2p_14230_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
 		d_l2_conn->diag_msg = NULL;
 
 		/* Check for negative response */
-		if (rmsg->data[0] != DIAG_KW2K_RC_NR) {
+		if (rmsg && rmsg->data[0] != DIAG_KW2K_RC_NR) {
 			/* Success */
 			break;
 		}
 
-		if (rmsg->data[2] == DIAG_KW2K_RC_B_RR) {
+		if (rmsg && rmsg->data[2] == DIAG_KW2K_RC_B_RR) {
 			/*
 			 * Msg is busyRepeatRequest
 			 * So send again (if retries>0).
@@ -1102,7 +1102,7 @@ dl2p_14230_request(struct diag_l2_conn *d_l2_conn, struct diag_msg *msg,
 			continue;
 		}
 
-		if (rmsg->data[2] == DIAG_KW2K_RC_RCR_RP) {
+		if (rmsg && rmsg->data[2] == DIAG_KW2K_RC_RCR_RP) {
 			/*
 			 * Msg is a requestCorrectlyRcvd-RspPending
 			 * so do read again
@@ -1151,8 +1151,6 @@ dl2p_14230_timeout(struct diag_l2_conn *d_l2_conn) {
 	diag_l1_debug=0;
 	diag_l0_debug=0;
 
-	msg.data = data;
-
 	/* Prepare the "keepalive" message */
 	if (dp->modeflags & ISO14230_IDLE_J1978) {
 		/* Idle using J1978 / J1979 keep alive message : SID 1 PID 0 */
@@ -1166,6 +1164,8 @@ dl2p_14230_timeout(struct diag_l2_conn *d_l2_conn) {
 		msg.src = 0;	/* Use default */
 		data[0] = DIAG_KW2K_SI_TP;
 	}
+	
+	msg.data = data;
 
 	/*
 	 * There is no point in checking for errors, or checking

--- a/scantool/diag_l3_saej1979.c
+++ b/scantool/diag_l3_saej1979.c
@@ -709,11 +709,10 @@ static int diag_l3_j1979_keepalive(struct diag_l3_conn *d_l3_conn) {
 	 * Service 1 Pid 0 request is the SAEJ1979 idle message
 	 * XXX Need to get the address bytes correct
 	 */
-
-	msg.data = data;
 	msg.len = 2;
 	data[0] = 1 ;		/* Mode 1 */
 	data[1] = 0; 		/* Pid 0 */
+	msg.data = data;
 
 	/*
 	 * And set the source address, if no sends have happened, then

--- a/scantool/diag_os.h
+++ b/scantool/diag_os.h
@@ -34,7 +34,7 @@ extern "C" {
 
 #include <stdbool.h>
 
-#ifdef WIN32
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 	#include <windows.h>
 	typedef DWORD OS_ERRTYPE;
 #else
@@ -116,7 +116,7 @@ unsigned long long diag_os_hrtus(unsigned long long hrdelta);
  * the backends use pthread, C11, winAPI etc.
  * lowest-common-denominator stuff here; regular mutexes (not necessarily recursive etc)
  */
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 	#include <windows.h>
 	// No static mutex initialization on Windows ( CRITICAL_SECTION is an opaque type)
 	typedef CRITICAL_SECTION diag_mtx;

--- a/scantool/diag_os_win.c
+++ b/scantool/diag_os_win.c
@@ -414,7 +414,7 @@ void diag_os_calibrate(void) {
 		//fragile. We just print it out; there's not much we can do to fix this.
 		if ((min < counts) || (avgerr > 900))
 			printf("diag_os_millisleep(%d) off by %+"PRId64"%% (%+"PRId64"us)"
-			"; spread=%"PRIu64"%%\n", testval, (avgerr*100/1000)/testval, avgerr, ((max-min)*100)/counts);
+			"; spread=%"PRId64"%%\n", testval, (avgerr*100/1000)/testval, avgerr, ((max-min)*100)/counts);
 
 
 		if (testval>=30)

--- a/scantool/scantool_cli.c
+++ b/scantool/scantool_cli.c
@@ -390,10 +390,17 @@ static int
 cmd_date(UNUSED(int argc), UNUSED(char **argv)) {
 	struct tm *tm;
 	time_t now;
+	char str[256];
 
 	now = time(NULL);
 	tm = localtime(&now);
-	printf("%s", asctime(tm));
+	if (strftime(str, sizeof(str), "%a %b %d %H:%M:%S %Y", tm) == 0) {
+		printf("unable to format timestamp");
+	}
+	else {
+		printf("%s", str);
+	}
+	
 
 	return CMD_OK;
 }
@@ -434,6 +441,7 @@ cmd_log(int argc, char **argv) {
 	char autofilename[20]="";
 	char *file;
 	time_t now;
+	char timestr[256];
 	int i;
 
 	file=autofilename;
@@ -476,9 +484,12 @@ cmd_log(int argc, char **argv) {
 
 	fprintf(global_logfp, "%s\n", LOG_FORMAT);
 	log_timestamp("#");
-	fprintf(global_logfp, "logging started at %s",
-		asctime(localtime(&now)));
-
+	if (strftime(timestr, sizeof(timestr), "%a %b %d %H:%M:%S %Y", localtime(&now)) == 0) {
+		fprintf(global_logfp, "unable to format timestamp");
+	}
+	else {
+		fprintf(global_logfp, "logging started at %s", timestr);
+	}
 	printf("Logging to file %s\n", file);
 	return CMD_OK;
 }
@@ -765,7 +776,7 @@ cmd_source(int argc, char **argv) {
 //rc_file : returns CMD_OK or CMD_EXIT only.
 static int
 rc_file(void) {
-	int rv;
+	int rv = CMD_FAILED;
 	//this loads either a $home/.<progname>.rc or ./<progname>.ini (in order of preference)
 	//to load general settings.
 


### PR DESCRIPTION
## Scope
The scope of this PR is to integrate static code checks with Cppcheck. This integration will be done in two steps:

1. Determine a sensible Cppcheck configuration (as Cppcheck GUI projects) and initially change sources to remove any warning found with this configuration. This configuration should be able to run against an unconfigured source tree.
2. Integrate the Cppcheck checks into the cmake build process itself to be run as part of the configured build process. 

### What has changed?
#### Source Files:

`CMakeLists.txt`
`scantool/CMakeLists.txt`

- Changed the minimum required Cmake version to `3.10` to be able to use the build-in cppcheck integration.
- Added The Cppcheck target to the build process. The analysis will now run before any compilation of a source file.
- The Cppcheck integration is optional, which means if Cppcheck is not found in during Cmake configuration the Cppcheck target will not be created.
- The analysis target is configured to fail if any warnings are found meaning that the software can only be build successfully if warning free.
 
`cppcheck\win32.cppcheck`
`cppcheck\linux.cppcheck`
`cppcheck\run-cppckeck.bat`

- Moved the central project file from the root directory into the subdirectory `cppcheck` and split it into two platform specific configuration. This has the advantage that the sources will be tested more closely to the actual platform configured build process.
- Added defines to enable the checks to test as much source code as possible. 
- The `unsignedLessThanZero` warning was added to the exclude list. This warning can be addressed in an later PR/commit to reduce the number of changed files for this PR.
- I included a Windows batch file to run both test from the command line for convenience.

`scantool/diag.h`
`scantool/diag_os.h`
`cconf.h.in`

- Added the combination of defines (`defined(_WIN32) || defined(__WIN32__) || defined(WIN32)`) to define the Windows platform. This is done to unify the Windows detection in the header files and therefore only the `_WIN32` define must be included in the Cppcheck project file.

`scantool/diag_l2_iso14230.c`

- Removed a `nullPointerRedundantCheck` warning. This change should be reviewed. 
- Removed a `unreadVariable` warning by moving the `msg.data = data;` to make the intention of the code clear to Cppcheck.

`scantool/diag_l2_saej1979.c`

- Removed a `unreadVariable` warning by moving the `msg.data = data;` to make the intention of the code clear to Cppcheck.

`scantool/scantool_cli.c`

- Replaced calls to `asctime()` with equivalent calls to the `strftime()` function to remove an obsolete warning.
- Removed an `uninitializedVariable` warning caused by some defines in the code. 

`scantool/diag_os_win.c`

- Corrected a `portability` warning issued for the Borland compiler environment because the formatter was signed and the parameter was unsigned (`LONGLONG`). 

`scantool/diag_cfg.c`

- Removed an  `uninitializedVariable` warning issued for the Borland bcc32x/bcc64 compiler environment caused by the `assert` in the `default` branch of the `switch` statement.  

#### Tested Environments:

All changes where tested using these environments:

Cppcheck:
- Cppcheck 2.3 on Windows 
- Cppcheck 1.86 on Debian (Limited tests because the command line version requires version 1.90 or later to be able to use the Cppcheck GUI project file format. Currently my Debian 10 systems have no Cppcheck 1.90 or better prebuild packages available)

Compiler/Build Environment:
- Visual Studio 2019 (x86/x64) (integrated cmake and cmake 3.19.3)
- Visual Studio Code on Windows (MinGW, MinGW64, BCC, MSVC)   (cmake 3.10.0 and higher)
- Visual Studio Code remote on WSL (cmake 3.13.4 default installation Debian)
- Debian (cmake  3.13.4  default installation Debian)

Perhaps you like the changes and accept this merge request. 

Thanks!

@fenugrec @nsajko 