### PR TITLE
Remove unsignedLessThanZero warnings and suppression.

### DIFF
--- a/cppcheck/linux.cppcheck
+++ b/cppcheck/linux.cppcheck
@@ -24,6 +24,5 @@
     </exclude>
     <suppressions>
         <suppression>variableScope</suppression>
-		<suppression>unsignedLessThanZero</suppression>
     </suppressions>
 </project>

--- a/cppcheck/win32.cppcheck
+++ b/cppcheck/win32.cppcheck
@@ -21,6 +21,5 @@
     </exclude>
     <suppressions>
         <suppression>variableScope</suppression>
-        <suppression>unsignedLessThanZero</suppression>
     </suppressions>
 </project>

--- a/doc/build_system.txt
+++ b/doc/build_system.txt
@@ -5,17 +5,34 @@ freediag build system overview and compilation instructions
 
 As of 2021/02 :
 
-* Visual Studio 2019 (x86/x64) (integrated cmake and cmake 3.19.3) works
-* Visual Studio Code on Windows (MinGW, MinGW64, BCC, MSVC) (cmake 3.6.0 and higher) works
+* Visual Studio 2019 (x86/x64) (integrated cmake) works
+* Visual Studio Code on Windows (MinGW, MinGW64, BCC, MSVC) (cmake 3.10.0 and higher) works
 * Visual Studio Code remote on WSL (cmake 3.13.4 default installation debian) works
-* Visual Studio 2019 builds will not run on XP but will run on 7 and higher.
-* MinGW and Borland work for Windows XP
+* Visual Studio 2019 builds will not run on Windows XP but will run on Windows 7 and higher.
+* Binaries build with MinGW and Borland/Embarcadero work for Windows XP
 
 
 **************** instructions for cmake ****************
 
+**** 1A- Steps to compile freediag on MS Windows Visual Studio/Visual Studio Code ****
 
-**** 1A- Steps to compile freediag on MS Windows ****
+To compile freediag on win using these IDEs, the general process is as such
+    -extract the source tree (git clone, or a source package).
+    -make sure cmake version 3.10 or higher is installed and %PATH% holds the cmake/bin directory.
+	 Visual Studio 2019 has a cmake installation integrated so no extra action is required. 
+	-open the source directory from the IDE. Visual Studio 2019 has the option "Open local folder" which 
+	 will start the cmake integration automatically. There is no need to generate MSBuild project files 
+	 with cmake although this works as well. Visual Studio Code may suggest the installation of serveral 
+	 extensions (e.g. C/C++ support, IntelliSense, CMake Tools). 
+	-the cmake integration in both IDEs will guide you through the cmake configuration process.
+	-Visual Studio Code will detect existing MinGW and Visual Studio Build Tool installations. The 
+	 Borland/Embarcadero Compiler (e.g Embarcadero C++ Compiler Tools or C++ Builder Community Edition)
+	 can be added manually. For Visual Studio 2019 the build targets x86/x64 Debug/Release are tested.
+	-After configuration start the build process in the IDE. 
+
+
+
+**** 1B- Steps to compile freediag on MS Windows using Cmake GUI and MinGW ****
 
 To compile freediag on win, the general process is as such (rename directories as required)
 	-make sure cmake is installed and %PATH% holds the cmake/bin directory
@@ -31,8 +48,7 @@ To compile freediag on win, the general process is as such (rename directories a
 
 
 
-
-**** 1B- Steps to compile freediag on linux ****
+**** 1C- Steps to compile freediag on linux ****
 
 The instructions given above for Win may be used almost as-is on linux; here are methods without using
 "cmake-gui"

--- a/scantool/CMakeLists.txt
+++ b/scantool/CMakeLists.txt
@@ -38,7 +38,6 @@ if (NOT (CPPCHECK_BIN MATCHES "NOTFOUND"))
 			"--suppress=missingSystemInclude"
 			"--suppress=unmatchedSuppression"
 			"--suppress=variableScope"
-			"--suppress=unsignedLessThanZero"
             "--error-exitcode=1"
             "--inline-suppr"
        )

--- a/scantool/diag_l0_br.c
+++ b/scantool/diag_l0_br.c
@@ -187,7 +187,7 @@ static int
 br_write(struct diag_l0_device *dl0d, const void *dp, size_t txlen) {
 	struct br_device *dev = dl0d->l0_int;
 
-	if (txlen <= 0) {
+	if (txlen == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 
@@ -632,7 +632,7 @@ const void *data, size_t len) {
 
 	dev = (struct br_device *)dl0d->l0_int;
 
-	if (len <= 0) {
+	if (len == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 

--- a/scantool/diag_l0_dumb.c
+++ b/scantool/diag_l0_dumb.c
@@ -652,7 +652,7 @@ const void *data, size_t len) {
 
 	struct dumb_device *dev = dl0d->l0_int;
 
-	if (len <= 0) {
+	if (len == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 
@@ -680,7 +680,7 @@ void *data, size_t len, unsigned int timeout) {
 	int rv;
 	struct dumb_device *dev = dl0d->l0_int;
 
-	if (len <= 0) {
+	if (len == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 

--- a/scantool/diag_l0_dumbtest.c
+++ b/scantool/diag_l0_dumbtest.c
@@ -682,7 +682,7 @@ const void *data, size_t len) {
 	 * as the L1 code that called this will be adding the P4 gap between
 	 * bytes
 	 */
-	if (len <= 0) {
+	if (len == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 

--- a/scantool/diag_l0_elm.c
+++ b/scantool/diag_l0_elm.c
@@ -935,7 +935,7 @@ elm_send(struct diag_l0_device *dl0d,
 	int rv;
 	unsigned int i;
 
-	if (len <= 0) {
+	if (len == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 

--- a/scantool/diag_l0_me.c
+++ b/scantool/diag_l0_me.c
@@ -427,7 +427,7 @@ static int
 muleng_write(struct diag_l0_device *dl0d, const void *dp, size_t txlen) {
 	struct muleng_device *dev = dl0d->l0_int;
 
-	if (txlen <= 0) {
+	if (txlen == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 
@@ -634,7 +634,7 @@ const void *data, size_t len) {
 
 	dev = (struct muleng_device *)dl0d->l0_int;
 
-	if (len <= 0) {
+	if (len == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 

--- a/scantool/diag_l0_sim.c
+++ b/scantool/diag_l0_sim.c
@@ -668,7 +668,7 @@ int sim_send(struct diag_l0_device *dl0d,
 		 const void *data, const size_t len) {
 	struct sim_device *dev = dl0d->l0_int;
 
-	if (len <= 0) {
+	if (len == 0) {
 		return diag_iseterr(DIAG_ERR_BADLEN);
 	}
 

--- a/scantool/diag_tty_win.c
+++ b/scantool/diag_tty_win.c
@@ -300,7 +300,7 @@ ssize_t diag_tty_write(ttyp *ttyh, const void *buf, const size_t count) {
 		return diag_iseterr(DIAG_ERR_GENERAL);
 	}
 
-	if (count <= 0)
+	if (count == 0)
 		return diag_iseterr(DIAG_ERR_BADLEN);
 
 	if (! WriteFile(wti->fd, buf, count, &byteswritten, pOverlap)) {
@@ -334,7 +334,7 @@ diag_tty_read(ttyp *ttyh, void *buf, size_t count, unsigned int timeout) {
 	pOverlap=NULL;
 	COMMTIMEOUTS devtimeouts;
 
-	if ((count <= 0) || (timeout <= 0)) return DIAG_ERR_BADLEN;
+	if ((count == 0) || (timeout == 0)) return DIAG_ERR_BADLEN;
 
 	DIAG_DBGM(diag_l0_debug, DIAG_DEBUG_READ, DIAG_DBGLEVEL_V,
 		FLFMT "tty_read: ttyh=%p, fd=%p, len=%zu, t=%u\n",


### PR DESCRIPTION
## Scope
This is a quick follow-up to PR #70 to removed the `unsignedLessThanZero` warning and suppressions from the source tree/build system. 

### What has changed?
#### Source Files:

`scantool/CMakeLists.txt`

- Removed the  `unsignedLessThanZero` suppression.

`cppcheck\win32.cppcheck`
`cppcheck\linux.cppcheck`

- Removed the  `unsignedLessThanZero` suppression.

`various source files`

- Replaced the `<=` operator with `==`.

#### Tested Environments:

All changes where tested using these environments:

Cppcheck:
- Cppcheck 2.3 on Windows 
- Cppcheck 1.86 on Debian (Limited tests because the command line version requires version 1.90 or later to be able to use the Cppcheck GUI project file format. Currently my Debian 10 systems have no Cppcheck 1.90 or better prebuild packages available)

Compiler/Build Environment:
- Visual Studio 2019 (x86/x64) (integrated cmake and cmake 3.19.3)
- Visual Studio Code on Windows (MinGW, MinGW64, BCC, MSVC)   (cmake 3.10.0 and higher)
- Visual Studio Code remote on WSL (cmake 3.13.4 default installation Debian)
- Debian (cmake  3.13.4  default installation Debian)

Perhaps you like the changes and accept this merge request. 

Thanks!

@fenugrec 