### PR TITLE
Made sources compile with the clang compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,10 @@ elseif (MSVC)
 		#require at least winXP
 		message(WARNING "Visual Studio version before 15 (2017) may not work ! Proceed at your risk !")
 	endif ()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    #using regular Clang or AppleClang
+	#set all warnings as errors for clang based compiler.
+	add_compile_options("-Wall" "-Werror" "-pedantic" "-pedantic-errors" "-std=gnu99")
 else ()
 	message(WARNING "non-gcc compiler, verify compiler options !")
 	#not sure what we should use on other compilers.

--- a/doc/build_system.txt
+++ b/doc/build_system.txt
@@ -23,16 +23,16 @@ As of 2021/02 :
 To compile freediag on win using these IDEs, the general process is as such
     -extract the source tree (git clone, or a source package).
     -make sure cmake version 3.10 or higher is installed and %PATH% holds the cmake/bin directory.
-	 Visual Studio 2019 has a cmake installation integrated so no extra action is required. 
-	-open the source directory from the IDE. Visual Studio 2019 has the option "Open local folder" which 
-	 will start the cmake integration automatically. There is no need to generate MSBuild project files 
-	 with cmake although this works as well. Visual Studio Code may suggest the installation of serveral 
-	 extensions (e.g. C/C++ support, IntelliSense, CMake Tools). 
+	 Visual Studio 2019 has a cmake installation integrated so no extra action is required.
+	-open the source directory from the IDE. Visual Studio 2019 has the option "Open local folder" which
+	 will start the cmake integration automatically. There is no need to generate MSBuild project files
+	 with cmake although this works as well. Visual Studio Code may suggest the installation of serveral
+	 extensions (e.g. C/C++ support, IntelliSense, CMake Tools).
 	-the cmake integration in both IDEs will guide you through the cmake configuration process.
-	-Visual Studio Code will detect existing MinGW and Visual Studio Build Tool installations. The 
+	-Visual Studio Code will detect existing MinGW and Visual Studio Build Tool installations. The
 	 Borland/Embarcadero Compiler (e.g Embarcadero C++ Compiler Tools or C++ Builder Community Edition)
 	 can be added manually. For Visual Studio 2019 the build targets x86/x64 Debug/Release are tested.
-	-After configuration start the build process in the IDE. 
+	-After configuration start the build process in the IDE.
 
 **** 1B- Steps to compile freediag on win with MS Windows Visual Studio 2019 for Windows XP (toolset 141_xp) ****
 
@@ -77,7 +77,7 @@ The instructions given above for Win may be used almost as-is on linux; here are
 	-extract the source tree (git clone, or a source package) to  <srcdir>
 	-make an empty build directory not far from the source tree, I recommend <srcdir>/../<builddir>
 	-cd to builddir (important !!)
-	
+
 	either A) (preferred, if ncurses is available)
 		-run "ccmake [-G <generator_name>] ../<srcdir>"
 		(note: specifying -G <generator name> may be optional, I think it defaults to "UNIX Makefiles" )
@@ -88,11 +88,11 @@ The instructions given above for Win may be used almost as-is on linux; here are
 		-run "cmake [-G <generator_name>] ../<srcdir>" ; example : "cmake ../freediag"
 		(note: specifying -G <generator name> may be optional, I think it defaults to "UNIX Makefiles"
 		 which is usually fine.)
-	
+
 		-As required, run "cmake -L" to view current cache values. This is similar to "./configure --help".
 		-As required, run "cmake -D <var>:<type>=<value>" to modify one of the previously listed values, such as
-		 USE_RCFILE, etc. Example : "cmake -D USE_RCFILE:BOOL=ON" 
-		 
+		 USE_RCFILE, etc. Example : "cmake -D USE_RCFILE:BOOL=ON"
+
 	then
 	-run make; or open IDE project file if applicable
 
@@ -104,7 +104,7 @@ If generating makefiles, there are a few special targets added by CMake :
 	- make help		//show available targets
 
 Once the Makefiles are generated, it's usually not necessary to run cmake again unless the CMakeLists.txt files
-were changed, or build options were changed. 
+were changed, or build options were changed.
 
 
 

--- a/scantool/diag_tty_unix.c
+++ b/scantool/diag_tty_unix.c
@@ -299,7 +299,8 @@ static int _tty_setspeed(ttyp *tty_int, unsigned int spd) {
 	unsigned int	spd_real;	//validate baud rate precision
 	struct termios st_new;
 	int spd_done=0;	//flag success
-	int rv, fd;
+	int rv = 1;
+	int fd;
 
 	fd = uti->fd;
 

--- a/scantool/scantool_cli.c
+++ b/scantool/scantool_cli.c
@@ -367,9 +367,8 @@ help_common(int argc, char **argv, const struct cmd_tbl_entry *cmd_table) {
 		if (ctp->flags & FLAG_CUSTOM) {
 			/* list custom subcommands too */
 			printf("Custom commands for the current level:\n");
-			char cust_special[]="?";
-			char *pcs = cust_special;
-			char **temp_argv = &pcs;
+			char *cust_special[]= { "?", NULL };
+			char **temp_argv = &cust_special[0];
 			ctp->routine(1, temp_argv);
 		}
 		ctp++;

--- a/scantool/scantool_set.c
+++ b/scantool/scantool_set.c
@@ -275,7 +275,7 @@ cmd_set_show(UNUSED(int argc), UNUSED(char **argv)) {
 static int cmd_set_interface(int argc, char **argv) {
 	const struct diag_l0 *iter;
 
-	if (argc <= 1) {
+	if (argc <= 1 || argv == NULL) {
 		printf("interface: using %s\n",
 			global_cfg.l0name);
 		return CMD_OK;


### PR DESCRIPTION
## Scope
The scope of this PR is to make the source tree configure/compile with the clang compiler on Linux/UNIX. My experiences have shown that it is a good idea to have ad least two working compiler configuration per platform. This configuration should work as well on macOS to compile the sources with the native compiler there (called AppleClang).  

### What has changed?
#### Source Files:

`CMakeLists.txt`

- Added support for Clang compilers - this should work for the Apple Clang compiler on macOS as well (untested). 

`doc/build_system.txt`

- Removed some weird trailing whitespaces (now I know what you meant).

`scantool/diag_tty_unix.c `

- Initialized the variable `rv` to avoid `uninitializedVariable` warning. 

scantool/scantool_cli.c

- Changed the initialization of the `argv`array because of `unreadValue` warning. These new statements should be equivalent.

`scantool/scantool_set.c`

- Added a check for `argv == NULL` to remove `nullPointerDereference` warning. This could have been a false positive warning in cppcheck 1.86 on linux. The warning was not issued with cppcheck 2.3 but I think it does not hurt.

#### Tested Environments:

All changes where tested using these environments:

Cppcheck:
- Cppcheck 1.86 and 2.3 on Debian.

Compiler/Build Environment:
- Debian gcc 8 (cmake  3.13.4  default installation Debian)
- Debian clang 7.0.1  (cmake  3.13.4  default installation Debian)

Perhaps you like the changes and accept this merge request. 

Thanks!

@fenugrec 