### PR TITLE
Volvo: Command to reset Service Reminder Light, few live data changes

### DIFF
--- a/scantool/diag_l7_d2.h
+++ b/scantool/diag_l7_d2.h
@@ -4,7 +4,7 @@
  *	freediag - Vehicle Diagnostic Utility
  *
  *
- * Copyright (C) 2017 Adam Goldman
+ * Copyright (C) 2017, 2023 Adam Goldman
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,6 +43,7 @@ int diag_l7_d2_read(struct diag_l2_conn *d_l2_conn, enum l7_namespace ns, uint16
 int diag_l7_d2_dtclist(struct diag_l2_conn *d_l2_conn, int buflen, uint8_t *out);
 int diag_l7_d2_cleardtc(struct diag_l2_conn *d_l2_conn);
 int diag_l7_d2_io_control(struct diag_l2_conn *d_l2_conn, uint8_t id, uint8_t reps);
+int diag_l7_d2_run_routine(struct diag_l2_conn *d_l2_conn, uint8_t id);
 
 #if defined(__cplusplus)
 }

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -685,11 +685,8 @@ static enum cli_retval cmd_850_ping(int argc, UNUSED(char **argv)) {
  * scaled value.
  */
 static void interpret_value(enum l7_namespace ns, uint16_t addr, UNUSED(int len), uint8_t *buf) {
-#if 0
-	/* Bench tested, but not verified on vehicle */
 	static const char *mode_selector_positions[]={"Open","S","E","W","Unknown"};
 	static const char *driving_modes[]={"Economy","Sport","Winter","Unknown"};
-#endif
 	float volts;
 	int16_t deg_c;
 	uint8_t ecu = global_l2_conn->diag_l2_destaddr;
@@ -712,11 +709,8 @@ static void interpret_value(enum l7_namespace ns, uint16_t addr, UNUSED(int len)
 	} else if (ns==NS_LIVEDATA && ecu==0x7a && addr==0x1A00) {
 		printf("Long term fuel trim, multiplicative: %+.1f%%\n", (float)buf[0]*100/128-100);
 	} else if (ns==NS_LIVEDATA && ecu==0x6e && addr==0x0500) {
-#if 0
-		/* Bench tested, but not verified on vehicle */
 		printf("Mode selector: MS1 %s, MS2 %s, switch position %s\n", (buf[0]&1)?"low":"high", (buf[0]&2)?"low":"high", CLAMPED_LOOKUP(mode_selector_positions, buf[0]));
 		printf("Driving mode: %s\n", CLAMPED_LOOKUP(driving_modes, buf[1]));
-#endif
 	} else if (ns==NS_LIVEDATA && ecu==0x6e && addr==0x0C00) {
 		/* Full scale should be 1023, although highest value seen in
 		   bench testing was 1020 */

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -687,6 +687,7 @@ static enum cli_retval cmd_850_ping(int argc, UNUSED(char **argv)) {
 static void interpret_value(enum l7_namespace ns, uint16_t addr, UNUSED(int len), uint8_t *buf) {
 	static const char *mode_selector_positions[]={"Open","S","E","W","Unknown"};
 	static const char *driving_modes[]={"Economy","Sport","Winter","Unknown"};
+	static const char *warmup_states[]={"in progress or engine off","completed","not possible","status unknown"};
 	float volts;
 	int16_t deg_c;
 	uint8_t ecu = global_l2_conn->diag_l2_destaddr;
@@ -698,6 +699,12 @@ static void interpret_value(enum l7_namespace ns, uint16_t addr, UNUSED(int len)
 		printf("Battery voltage: %.1f V\n", (float)buf[0]*29750/8250*5/255);
 	} else if (ns==NS_MEMORY && ecu==0x10 && addr==0x36) {
 		printf("Battery voltage: %.1f V\n", (float)buf[0]*29750/8250*5/255);
+	} else if (ns==NS_LIVEDATA && ecu==0x7a && addr==0x0A00) {
+		printf("Warm-up %s\n", CLAMPED_LOOKUP(warmup_states, (buf[0]>>2)&3));
+		printf("MIL %srequested by TCM\n", (buf[0]&0x10)?"":"not ");
+		/* Low 2 bits supposedly indicate drive cycle and trip 
+		   complete, but don't make sense - can get set without the 
+		   car ever moving */
 	} else if (ns==NS_LIVEDATA && ecu==0x7a && addr==0x1000) {
 		/* ECU pin A4, MCU P7.4 input, divider ratio 8250/9460 */
 		printf("MAF sensor signal: %.2f V\n", (float)buf[0]*9460/8250*5/255);

--- a/scantool/scantool_850.c
+++ b/scantool/scantool_850.c
@@ -695,12 +695,12 @@ static void interpret_value(enum l7_namespace ns, uint16_t addr, UNUSED(int len)
 		printf("Engine Coolant Temperature: %dC (%dF)\n", buf[1]-80, (buf[1]-80)*9/5+32);
 	} else if (ns==NS_LIVEDATA && ecu==0x7a && addr==0x0300) {
 		/*ECU pin A27, MCU P7.1 input, divider ratio 8250/29750, 5Vref*/
-		printf("Battery voltage: %.1f V\n", (float)buf[0]*29750/8250*5/256);
+		printf("Battery voltage: %.1f V\n", (float)buf[0]*29750/8250*5/255);
 	} else if (ns==NS_MEMORY && ecu==0x10 && addr==0x36) {
-		printf("Battery voltage: %.1f V\n", (float)buf[0]*29750/8250*5/256);
+		printf("Battery voltage: %.1f V\n", (float)buf[0]*29750/8250*5/255);
 	} else if (ns==NS_LIVEDATA && ecu==0x7a && addr==0x1000) {
 		/* ECU pin A4, MCU P7.4 input, divider ratio 8250/9460 */
-		printf("MAF sensor signal: %.2f V\n", (float)buf[0]*9460/8250*5/256);
+		printf("MAF sensor signal: %.2f V\n", (float)buf[0]*9460/8250*5/255);
 	} else if (ns==NS_LIVEDATA && ecu==0x7a && addr==0x1800) {
 		printf("Short term fuel trim: %+.1f%%\n", (float)buf[0]*100/128-100);
 	} else if (ns==NS_LIVEDATA && ecu==0x7a && addr==0x1900) {


### PR DESCRIPTION
- Adds a command to reset the Service Reminder Light
- Driving mode live data has been verified on a vehicle, so uncomment it
- Slight change to scale factors
- One more pair of live data parameters decoded