### PR TITLE
Instead of checking clones first, check official.

### DIFF
--- a/scantool/diag_l0_elm.c
+++ b/scantool/diag_l0_elm.c
@@ -467,19 +467,19 @@ static int elm_open(struct diag_l0_device *dl0d, int iProtocol) {
 	}
 	// 2) identify valid VS clone devices.
 	rv=0;   // temp "device identified" flag
-	for (i=0; elm_clones[i]; i++) {
-		if (strstr((char *)rxbuf, elm_clones[i])) {
-			printf("Clone ELM found, v%s. Expect inferior performance\n", elm_clones[i]);
-			dev->elmflags |= ELM_32x_CLONE;
+	for (i=0; elm_official[i]; i++) {
+		if (strstr((char *)rxbuf, elm_official[i])) {
+			printf("Official ELM found, v%s\n", elm_official[i]);
 			rv=1;
 			break;
 		}
 	}
 
 	if (rv==0) {
-		for (i=0; elm_official[i]; i++) {
-			if (strstr((char *)rxbuf, elm_official[i])) {
-				printf("Official ELM found, v%s\n", elm_official[i]);
+		for (i=0; elm_clones[i]; i++) {
+			if (strstr((char *)rxbuf, elm_clones[i])) {
+				printf("Clone ELM found, v%s. Expect inferior performance\n", elm_clones[i]);
+				dev->elmflags |= ELM_32x_CLONE;
 				rv=1;
 				break;
 			}


### PR DESCRIPTION
The current code has a bug where if you are on an official `1.4b` version (for example the OBDLink MX+ 3.1) it is detected as a clone by the `1.4` version string in the list of clones, since `strstr("1.4", "1.4b")` passes.

Reversing the test and looking for official versions first fixes things for me, and it doesn't introduce any problems, since none of the official versions match the clone versions.

However, there are other fixes possible, let me know if they are preferred.

_Updated to refer to 1.4b instead of 1.4a_